### PR TITLE
fix: sync initialEmail prop when modal opens

### DIFF
--- a/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
@@ -59,6 +59,13 @@ export const SignupModal = ({ open, onOpenChange, initialEmail, initialStep = 1 
   const { mutate: createBilling, isPending: isBilling } = useCreateBilling();
   const { track } = useAmplitude();
 
+  // Sync initialEmail when modal opens
+  useEffect(() => {
+    if (open && initialEmail) {
+      setEmail(initialEmail);
+    }
+  }, [open, initialEmail]);
+
   // Guard step 3: only allow if user completed signup (email in sessionStorage)
   useEffect(() => {
     if (initialStep === 3) {


### PR DESCRIPTION
Closes #15

O `useState(initialEmail)` só captura o valor no mount. Adicionado `useEffect` que sincroniza `initialEmail` → `email` quando `open` muda pra `true`.

**Arquivo:** `signup-modal.tsx`
**Mudança:** +7 linhas (1 useEffect)