### PR TITLE
feat: migrate billing from AbacatePay v1 to v2

### DIFF
--- a/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
@@ -21,6 +21,8 @@ const SESSION_NAME_KEY = "agendabela_signup_name";
 const SESSION_PHONE_KEY = "agendabela_signup_phone";
 const SESSION_MAGIC_LINK_SENT = "agendabela_magic_link_sent";
 
+// Note: No CPF field needed — AbacatePay v2 only requires email for customer.
+
 interface SignupModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -189,8 +191,9 @@ export const SignupModal = ({ open, onOpenChange, initialEmail, initialStep = 1 
     track("agendabela/signup-modal/payment_click", { email });
 
     const customerName = name || sessionStorage.getItem(SESSION_NAME_KEY) || "";
+    const customerPhone = phone.replace(/\D/g, "") || sessionStorage.getItem(SESSION_PHONE_KEY) || "";
     createBilling(
-      { email, name: customerName },
+      { email, name: customerName, phone: customerPhone },
       {
         onSuccess: (data) => {
           if (data.url) {

--- a/src/app/api/agendabela/create-billing/route.ts
+++ b/src/app/api/agendabela/create-billing/route.ts
@@ -1,16 +1,24 @@
 import { NextResponse } from "next/server";
 
-// R$1,00 (100 centavos) é validação do cartão, estornado automaticamente.
-// Cobrança recorrente de R$59,90 é gerenciada pelo backend após trial.
-const DEFAULT_AMOUNT_CENTS = 100;
+// AbacatePay v2 — Checkout API
+// Uses pre-registered products instead of inline product definitions.
+// Card validation product: R$1,00 (prod_wDeX06wJqPmqMk0zjzJ6j5NZ)
+// Actual subscription is managed by the backend after trial period.
+
+const ABACATE_PAY_V2_URL = "https://api.abacatepay.com/v2";
 
 const RETURN_URL =
   process.env.BILLING_RETURN_URL ||
   "https://tudoagenda.com.br/agendabela/automatize-seu-atendimento?payment=success";
 
+// Product ID for card validation (R$1,00). Override via env var if needed.
+const CARD_VALIDATION_PRODUCT_ID =
+  process.env.ABACATE_PAY_CARD_VALIDATION_PRODUCT_ID ||
+  "prod_wDeX06wJqPmqMk0zjzJ6j5NZ";
+
 export async function POST(req: Request) {
   try {
-    const { email, name } = await req.json();
+    const { email, name, phone } = await req.json();
 
     if (!email) {
       return NextResponse.json(
@@ -19,63 +27,85 @@ export async function POST(req: Request) {
       );
     }
 
-    if (!name) {
-      return NextResponse.json(
-        { error: "Nome é obrigatório" },
-        { status: 400 }
-      );
-    }
-
     const apiKey = process.env.ABACATE_PAY_API;
     if (!apiKey) {
-      console.error("ABACATE_PAY_API env var not set");
+      console.error("[Billing] ABACATE_PAY_API env var not set");
       return NextResponse.json(
         { error: "Configuração de pagamento indisponível" },
         { status: 500 }
       );
     }
 
-    const amountCents = Number(process.env.PLAN_AMOUNT_CENTS) || DEFAULT_AMOUNT_CENTS;
+    // 1. Create or find customer (only email is required in v2)
+    const customerPayload: Record<string, string> = { email };
+    if (name) customerPayload.name = name;
+    if (phone) customerPayload.cellphone = phone;
 
-    const response = await fetch(
-      "https://api.abacatepay.com/v1/billing/create",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify({
-          frequency: "ONE_TIME",
-          methods: ["CARD"],
-          products: [
-            {
-              externalId: "PRO-PLAN",
-              name: "Agenda Bela Pro",
-              quantity: 1,
-              price: amountCents,
-            },
-          ],
-          returnUrl: RETURN_URL,
-          completionUrl: RETURN_URL,
-          customer: { email, name },
-        }),
-      }
-    );
+    const customerRes = await fetch(`${ABACATE_PAY_V2_URL}/customers/create`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(customerPayload),
+    });
 
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      console.error("AbacatePay error:", errorData);
+    let customerId: string | undefined;
+
+    if (customerRes.ok) {
+      const customerData = await customerRes.json();
+      customerId = customerData.data?.id;
+    } else {
+      // Customer creation failed — log but continue without customerId
+      // The checkout will still work, just without pre-filled customer data
+      const customerError = await customerRes.json().catch(() => ({}));
+      console.warn("[Billing] Customer creation failed:", customerError);
+    }
+
+    // 2. Create checkout with card validation product
+    const checkoutPayload: Record<string, unknown> = {
+      items: [{ id: CARD_VALIDATION_PRODUCT_ID, quantity: 1 }],
+      methods: ["CARD"],
+      returnUrl: RETURN_URL,
+      completionUrl: RETURN_URL,
+    };
+
+    if (customerId) {
+      checkoutPayload.customerId = customerId;
+    }
+
+    const checkoutRes = await fetch(`${ABACATE_PAY_V2_URL}/checkouts/create`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(checkoutPayload),
+    });
+
+    if (!checkoutRes.ok) {
+      const errorData = await checkoutRes.json().catch(() => ({}));
+      console.error("[Billing] AbacatePay checkout error:", errorData);
       return NextResponse.json(
-        { error: "Erro ao criar link de pagamento" },
-        { status: response.status }
+        { error: "Erro ao criar link de pagamento. Tente novamente." },
+        { status: checkoutRes.status }
       );
     }
 
-    const data = await response.json();
-    return NextResponse.json({ url: data.data?.url || data.url });
+    const checkoutData = await checkoutRes.json();
+    const url = checkoutData.data?.url;
+
+    if (!url) {
+      console.error("[Billing] AbacatePay response missing URL:", checkoutData);
+      return NextResponse.json(
+        { error: "Resposta inválida do serviço de pagamento." },
+        { status: 502 }
+      );
+    }
+
+    return NextResponse.json({ url });
   } catch (error) {
-    console.error("Billing error:", error);
+    console.error("[Billing] Unexpected error:", error);
     return NextResponse.json(
       { error: "Erro interno ao processar pagamento" },
       { status: 500 }

--- a/src/app/api/agendabela/create-billing/route.ts
+++ b/src/app/api/agendabela/create-billing/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 // AbacatePay v2 — Checkout API
 // Uses pre-registered products instead of inline product definitions.
-// Card validation product: R$1,00 (prod_wDeX06wJqPmqMk0zjzJ6j5NZ)
+// Card validation product: R$1,00 — configurable via env var.
 // Actual subscription is managed by the backend after trial period.
 
 const ABACATE_PAY_V2_URL = "https://api.abacatepay.com/v2";
@@ -11,18 +11,35 @@ const RETURN_URL =
   process.env.BILLING_RETURN_URL ||
   "https://tudoagenda.com.br/agendabela/automatize-seu-atendimento?payment=success";
 
-// Product ID for card validation (R$1,00). Override via env var if needed.
+// Product ID for card validation (R$1,00).
 const CARD_VALIDATION_PRODUCT_ID =
   process.env.ABACATE_PAY_CARD_VALIDATION_PRODUCT_ID ||
   "prod_wDeX06wJqPmqMk0zjzJ6j5NZ";
 
+// --- Input validation helpers ---
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && email.length <= 254;
+}
+
+function sanitizePhone(phone: string): string {
+  return phone.replace(/\D/g, "").slice(0, 15);
+}
+
+function sanitizeName(name: string): string {
+  return name.trim().slice(0, 200);
+}
+
 export async function POST(req: Request) {
   try {
-    const { email, name, phone } = await req.json();
+    const body = await req.json();
+    const email = typeof body.email === "string" ? body.email.trim() : "";
+    const rawName = typeof body.name === "string" ? sanitizeName(body.name) : "";
+    const rawPhone = typeof body.phone === "string" ? sanitizePhone(body.phone) : "";
 
-    if (!email) {
+    if (!email || !isValidEmail(email)) {
       return NextResponse.json(
-        { error: "Email é obrigatório" },
+        { error: "Email inválido" },
         { status: 400 }
       );
     }
@@ -38,8 +55,8 @@ export async function POST(req: Request) {
 
     // 1. Create or find customer (only email is required in v2)
     const customerPayload: Record<string, string> = { email };
-    if (name) customerPayload.name = name;
-    if (phone) customerPayload.cellphone = phone;
+    if (rawName) customerPayload.name = rawName;
+    if (rawPhone.length >= 10) customerPayload.cellphone = rawPhone;
 
     const customerRes = await fetch(`${ABACATE_PAY_V2_URL}/customers/create`, {
       method: "POST",
@@ -53,13 +70,13 @@ export async function POST(req: Request) {
     let customerId: string | undefined;
 
     if (customerRes.ok) {
-      const customerData = await customerRes.json();
-      customerId = customerData.data?.id;
+      const customerData = await customerRes.json().catch(() => null);
+      customerId = customerData?.data?.id;
     } else {
-      // Customer creation failed — log but continue without customerId
-      // The checkout will still work, just without pre-filled customer data
+      // Customer creation failed — log but continue without customerId.
+      // v2 checkouts work without customerId; customer data just won't be pre-filled.
       const customerError = await customerRes.json().catch(() => ({}));
-      console.warn("[Billing] Customer creation failed:", customerError);
+      console.warn("[Billing] Customer creation failed (non-blocking):", customerError);
     }
 
     // 2. Create checkout with card validation product
@@ -86,14 +103,15 @@ export async function POST(req: Request) {
     if (!checkoutRes.ok) {
       const errorData = await checkoutRes.json().catch(() => ({}));
       console.error("[Billing] AbacatePay checkout error:", errorData);
+      // Don't forward upstream status codes — always return 502 for third-party failures
       return NextResponse.json(
         { error: "Erro ao criar link de pagamento. Tente novamente." },
-        { status: checkoutRes.status }
+        { status: 502 }
       );
     }
 
-    const checkoutData = await checkoutRes.json();
-    const url = checkoutData.data?.url;
+    const checkoutData = await checkoutRes.json().catch(() => null);
+    const url = checkoutData?.data?.url;
 
     if (!url) {
       console.error("[Billing] AbacatePay response missing URL:", checkoutData);

--- a/src/hooks/use-create-user.ts
+++ b/src/hooks/use-create-user.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { userService, CreateUserParams } from "@/services/user";
+import { userService, CreateUserParams, CreateBillingParams } from "@/services/user";
 import { useToast } from "@/hooks/use-toast";
 
 export function useCreateUser() {
@@ -19,13 +19,13 @@ export function useCreateBilling() {
   const { toast } = useToast();
 
   return useMutation({
-    mutationFn: ({ email, name }: { email: string; name: string }) =>
-      userService.createBilling(email, name),
-    onError: () => {
+    mutationFn: (params: CreateBillingParams) =>
+      userService.createBilling(params),
+    onError: (error: Error) => {
       toast({
         variant: "destructive",
         title: "Erro ao gerar link de pagamento",
-        description: "Tente novamente mais tarde",
+        description: error.message || "Tente novamente mais tarde",
       });
     },
   });

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -8,8 +8,8 @@ export interface CreateUserParams {
 
 export interface CreateBillingParams {
   email: string;
-  name: string;
-  phone: string;
+  name?: string;
+  phone?: string;
 }
 
 type CreateUserResponse = {

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -6,6 +6,12 @@ export interface CreateUserParams {
   phone: string;
 }
 
+export interface CreateBillingParams {
+  email: string;
+  name: string;
+  phone: string;
+}
+
 type CreateUserResponse = {
   success: boolean;
   profileId?: string;
@@ -47,11 +53,11 @@ export const userService = {
     return response.json();
   },
 
-  async createBilling(email: string, name: string): Promise<CreateBillingResponse> {
+  async createBilling(params: CreateBillingParams): Promise<CreateBillingResponse> {
     const response = await fetch(`/api/agendabela/create-billing`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, name }),
+      body: JSON.stringify(params),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Migração AbacatePay v1 → v2

Closes #26

### Problema
A v1 do AbacatePay passou a exigir `customer.name`, `cellphone` e `taxId` (CPF) obrigatórios. A v2 simplifica: só `email` é obrigatório no customer.

### O que mudou

**API route (`create-billing/route.ts`):**
- `POST /v2/customers/create` — cria customer com email + name/cellphone (opcionais)
- `POST /v2/checkouts/create` — cria checkout com product ID pré-cadastrado
- Produto de validação de cartão: `prod_wDeX06wJqPmqMk0zjzJ6j5NZ` (R\$1,00)
- Tratamento de erros melhorado (URL ausente, erros específicos)

**Service + Hook:**
- `createBilling` aceita `{email, name, phone}` — sem CPF
- Hook mostra mensagem de erro da API no toast

**Modal:**
- Passa phone junto com email e name pro billing
- **Sem campo CPF** (v2 não exige)

### Env vars necessárias no Railway (antes do merge)
- `ABACATE_PAY_API` → trocar pra key v2
- `ABACATE_PAY_CARD_VALIDATION_PRODUCT_ID` → `prod_wDeX06wJqPmqMk0zjzJ6j5NZ` (opcional, já tem fallback no código)

### Validação
- ✅ Testado contra API v2 real: checkout criado com sucesso
- ✅ Customer creation testada
- ✅ Lint: zero erros
- ✅ Build: OK
- ✅ Testes: 35/35 passando