### PR TITLE
feat: Ícones App Store e Play Store no modal de sucesso

### DIFF
--- a/public/images/badges/app-store.svg
+++ b/public/images/badges/app-store.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 135 40" width="135" height="40">
+  <rect width="135" height="40" rx="5" fill="#000"/>
+  <text x="42" y="14" fill="#fff" font-family="system-ui,-apple-system,sans-serif" font-size="8" letter-spacing="0.5">Baixar na</text>
+  <text x="42" y="28" fill="#fff" font-family="system-ui,-apple-system,sans-serif" font-size="14" font-weight="600">App Store</text>
+  <g transform="translate(10,7)" fill="#fff">
+    <path d="M18.9 10.2c0-2.6 2.1-3.8 2.2-3.9-1.2-1.8-3.1-2-3.7-2-1.6-.2-3.1.9-3.9.9-.8 0-2-.9-3.3-.9-1.7 0-3.3 1-4.1 2.5-1.8 3.1-.5 7.6 1.3 10.1.8 1.2 1.8 2.6 3.2 2.5 1.3-.1 1.7-.8 3.3-.8 1.5 0 1.9.8 3.2.8s2.3-1.2 3.1-2.5c1-1.4 1.4-2.8 1.4-2.8C21.5 14.1 18.9 13 18.9 10.2zM16.4 3.3c.7-.9 1.2-2 1-3.3-1 0-2.3.7-3 1.6-.6.8-1.2 2-1 3.2C14.5 4.9 15.7 4.2 16.4 3.3z" transform="scale(0.85)"/>
+  </g>
+</svg>

--- a/public/images/badges/google-play.svg
+++ b/public/images/badges/google-play.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 135 40" width="135" height="40">
+  <rect width="135" height="40" rx="5" fill="#000"/>
+  <text x="42" y="14" fill="#fff" font-family="system-ui,-apple-system,sans-serif" font-size="7" letter-spacing="0.3">DISPONÍVEL NO</text>
+  <text x="42" y="28" fill="#fff" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="600">Google Play</text>
+  <g transform="translate(10,8)">
+    <path d="M0 1.2C0 .5.2.1.6 0l13.3 12L.6 24c-.4-.2-.6-.5-.6-1.2V1.2z" fill="#4285F4"/>
+    <path d="M.6 0l13.3 12 4-3.6L.6 0z" fill="#EA4335"/>
+    <path d="M17.9 8.4L.6 0 13.9 12l4-3.6z" fill="#EA4335" opacity="0"/>
+    <path d="M.6 24l13.3-12 4 3.6L.6 24z" fill="#34A853"/>
+    <path d="M17.9 15.6l-4-3.6 4-3.6 4.5 2.5c.8.5.8 1.3 0 1.7l-4.5 3z" fill="#FBBC05"/>
+  </g>
+</svg>

--- a/src/app/agendabela/automatize-seu-atendimento/components/success-modal/success-modal.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/success-modal/success-modal.tsx
@@ -7,6 +7,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import Image from "next/image";
 
 interface SuccessModalProps {
   open: boolean;
@@ -14,6 +15,10 @@ interface SuccessModalProps {
   email?: string;
   tempPassword?: string;
 }
+
+// TODO: Update these URLs when the apps are published
+const APP_STORE_URL = "https://apps.apple.com";
+const PLAY_STORE_URL = "https://play.google.com";
 
 export const SuccessModal = ({ open, onOpenChange, email, tempPassword }: SuccessModalProps) => {
   const handleAccessPanel = () => {
@@ -35,7 +40,7 @@ export const SuccessModal = ({ open, onOpenChange, email, tempPassword }: Succes
               <div className="space-y-3 text-sm">
                 <div className="flex items-start gap-2">
                   <span className="text-lg flex-shrink-0">1️⃣</span>
-                  <span className="break-words">Acesse o sistema com seu e-mail e senha temporária.</span>
+                  <span className="break-words">Baixe o app ou acesse pelo navegador.</span>
                 </div>
                 <div className="flex items-start gap-2">
                   <span className="text-lg flex-shrink-0">2️⃣</span>
@@ -45,6 +50,38 @@ export const SuccessModal = ({ open, onOpenChange, email, tempPassword }: Succes
                   <span className="text-lg flex-shrink-0">3️⃣</span>
                   <span className="break-words">Compartilhe seu link e receba seus primeiros agendamentos.</span>
                 </div>
+              </div>
+
+              {/* Store Badges */}
+              <div className="flex items-center justify-center gap-3 pt-1">
+                <a
+                  href={APP_STORE_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="transition-transform hover:scale-105 active:scale-95"
+                >
+                  <Image
+                    src="/images/badges/app-store.svg"
+                    alt="Baixar na App Store"
+                    width={135}
+                    height={40}
+                    className="h-10 w-auto"
+                  />
+                </a>
+                <a
+                  href={PLAY_STORE_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="transition-transform hover:scale-105 active:scale-95"
+                >
+                  <Image
+                    src="/images/badges/google-play.svg"
+                    alt="Disponível no Google Play"
+                    width={135}
+                    height={40}
+                    className="h-10 w-auto"
+                  />
+                </a>
               </div>
               
               <div className="bg-blue-50 p-3 rounded-lg">


### PR DESCRIPTION
## O que faz

Adiciona badges oficiais de App Store e Google Play no modal de sucesso após cadastro.

### Mudanças
- Badges SVG em `public/images/badges/`
- Step 1 atualizado: 'Baixe o app ou acesse pelo navegador'
- Links genéricos por enquanto (TODO nos URLs pra atualizar quando apps forem publicados)
- Hover/active animations nos badges

### Build & Testes
✅ Build passou
✅ 35/35 testes passando

Closes #29