### PR TITLE
fix: Normalizar phone e corrigir envio do magic link na landing page

### DIFF
--- a/src/app/api/agendabela/create-user/route.ts
+++ b/src/app/api/agendabela/create-user/route.ts
@@ -101,7 +101,7 @@ export async function POST(req: Request) {
         headers: internalHeaders,
         body: JSON.stringify({
           name: salonName,
-          phone,
+          phone: phone.replace(/\D/g, ''),
           billingEmail: email,
           specialty: "Salão de Beleza",
           type: "salon",
@@ -117,6 +117,21 @@ export async function POST(req: Request) {
       }
     } catch (profileError) {
       console.error("Profile creation error:", profileError);
+    }
+
+    // 3. Send magic link via WhatsApp (non-blocking)
+    const cleanPhone = phone.replace(/\D/g, '');
+    try {
+      const magicRes = await fetch(`${BACKEND_API}/auth/magic-link`, {
+        method: "POST",
+        headers: internalHeaders,
+        body: JSON.stringify({ phone: cleanPhone, email }),
+      });
+      if (!magicRes.ok) {
+        console.warn("Magic link dispatch failed:", magicRes.status);
+      }
+    } catch (magicError) {
+      console.warn("Magic link dispatch error:", magicError);
     }
 
     return NextResponse.json({ success: true, profileId });

--- a/src/app/api/agendabela/send-magic-link/route.ts
+++ b/src/app/api/agendabela/send-magic-link/route.ts
@@ -5,7 +5,7 @@ const BACKEND_API =
   "https://api.agendabela.tudoagenda.com.br/api";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const PHONE_REGEX = /^\d{10,11}$/;
+const PHONE_REGEX = /^\d{10,13}$/;
 
 // In-memory rate limiter: max 3 calls per email per 5 minutes
 const RATE_LIMIT_MAX = 3;


### PR DESCRIPTION
## Bug

O magic link via WhatsApp **nunca era enviado** após cadastro na landing page. Três problemas:

### 1. Phone com máscara no create-user
`create-user/route.ts` mandava o phone direto pro backend sem limpar. O DTO do backend rejeita com 400 (`/^\d{10,13}$/`).

**Fix:** `phone.replace(/\D/g, '')` antes de enviar.

### 2. Magic link não disparado no create-user
O magic link só era disparado pelo `signup-modal` (step 3, após pagamento). Se o step 3 não rodasse, nenhum magic link era enviado.

**Fix:** Adicionar chamada `POST /auth/magic-link` no final do `create-user/route.ts` (non-blocking).

### 3. Regex de phone muito restritiva no send-magic-link
`PHONE_REGEX = /^\d{10,11}$/` rejeitava phones com prefixo 55 (12-13 dígitos).

**Fix:** `/^\d{10,13}$/`

### Verificações
- ✅ Build passou
- ✅ Lint ok (warning pré-existente)
- ✅ 35/35 testes passando