### PR TITLE
chore: meta tag de verificação de domínio do Meta Business

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ export default function RootLayout({
   return (
     <html lang="pt-br" className={lexend.variable}>
       <head>
+        <meta name="facebook-domain-verification" content="ejc4341iemcbhtlk85ih0f6fxxxf7b" />
         <link rel="preload" href="/agendabela-logo.png" as="image" type="image/png" />
         <link rel="preload" href="/gif-agendamento.gif" as="image" type="image/gif" />
         <Script


### PR DESCRIPTION
Adiciona a meta tag de verificação no `<head>` do layout root pra desbloquear:

- Domain verification do `tudoagenda.com.br` no Meta Business (cobre subdomínios)
- Aggregated Event Measurement no iOS (sem o domínio verificado, atribuição iOS quebra)
- Pré-requisito da Fase 1 do plano de medição (ADR 0003 no companion-os)

Token público de verificação (não é credencial — é só prova de posse). Após Amplify deployar, voltar no Meta Business → Brand Safety → Domínios → `tudoagenda.com.br` → Verificar.