### PR TITLE
chore: troca GTM container para o novo (Tudo Agenda)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,14 +28,14 @@ export default function RootLayout({
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-NCLL3WLW');`,
+})(window,document,'script','dataLayer','GTM-TSM8GGL6');`,
           }}
         />
       </head>
       <body>
         <noscript>
           <iframe
-            src="https://www.googletagmanager.com/ns.html?id=GTM-NCLL3WLW"
+            src="https://www.googletagmanager.com/ns.html?id=GTM-TSM8GGL6"
             height="0"
             width="0"
             style={{ display: 'none', visibility: 'hidden' }}


### PR DESCRIPTION
Substitui `GTM-NCLL3WLW` (container legado, criado por outra conta sem acesso) pelo novo container criado sob `tudoagendaagendabela@gmail.com`.

- Novo Account GTM: 'Tudo Agenda' (organização — vai abrigar containers de todos os SaaS futuros)
- Novo Container: 'Agenda Bela Web' (Web platform)
- Alinha com princípio de isolamento por SaaS

Após merge, Railway auto-deploya. Daí no GTM o novo container começa a receber hits da landing.