### PR TITLE
fix: move GTM para inline no <head> conforme padrão Google

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import "./globals.css";
 import { Providers } from "./providers";
-import Script from "next/script";
 import { Lexend } from 'next/font/google';
 
 const lexend = Lexend({
@@ -18,11 +17,8 @@ export default function RootLayout({
     <html lang="pt-br" className={lexend.variable}>
       <head>
         <meta name="facebook-domain-verification" content="ejc4341iemcbhtlk85ih0f6fxxxf7b" />
-        <link rel="preload" href="/agendabela-logo.png" as="image" type="image/png" />
-        <link rel="preload" href="/gif-agendamento.gif" as="image" type="image/gif" />
-        <Script
-          id="gtm-script"
-          strategy="afterInteractive"
+        {/* Google Tag Manager — must be as high as possible in <head> for proper detection by Search Console, Tag Assistant, etc. */}
+        <script
           dangerouslySetInnerHTML={{
             __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -31,6 +27,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-TSM8GGL6');`,
           }}
         />
+        <link rel="preload" href="/agendabela-logo.png" as="image" type="image/png" />
+        <link rel="preload" href="/gif-agendamento.gif" as="image" type="image/gif" />
       </head>
       <body>
         <noscript>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ export default function RootLayout({
     <html lang="pt-br" className={lexend.variable}>
       <head>
         <meta name="facebook-domain-verification" content="ejc4341iemcbhtlk85ih0f6fxxxf7b" />
+        <meta name="google-site-verification" content="DMHYDDq3HYq2eCbpCQsLPYTVWX5Svmrbdh0a0thP9Qc" />
         {/* Google Tag Manager — must be as high as possible in <head> for proper detection by Search Console, Tag Assistant, etc. */}
         <script
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
Substitui `<Script strategy="afterInteractive">` (next/script) por raw `<script>` inline no `<head>`, posicionado logo após as meta tags e antes dos preloads.

## Por quê

Search Console (e ferramentas de detecção tipo Tag Assistant, Pixel Helper) exigem que o snippet GTM esteja:
- No `<head>`, **alto na hierarquia** (antes de preloads e outros scripts)
- Renderizado no HTML inicial (não injetado via JS post-hydration)

`next/script` com `strategy="afterInteractive"` injeta o script depois da hidratação — por isso a verificação do Search Console via GTM falhou ("snippet em local incorreto").

## Mudança

- Removido `import Script from "next/script"` (não usado em outro lugar)
- Snippet agora é `<script dangerouslySetInnerHTML={{...}} />` direto no `<head>`, antes dos preloads
- IIFE inline cria `<script>` async dinâmico, então performance não regride (ainda async)
- noscript iframe no body permanece igual

## Referências

- https://developers.google.com/tag-platform/tag-manager/web ("as high as possible in head")
- ADR 0003 do companion-os