### PR TITLE
feat(medicao): eventos Tier 2 no dataLayer da landing principal Agenda Bela

### DIFF
--- a/src/app/agendabela/automatize-seu-atendimento/components/about/about.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/about/about.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import { StepComponent } from "../step";
 import Link from "next/link";
+import { pushAgendaBelaMainEvent } from "@/lib/analytics/dataLayer";
 
 export const AboutComponent = () => {
   return (
@@ -14,7 +17,18 @@ export const AboutComponent = () => {
         <StepComponent step="Step3" />
       </section>
       <Button asChild variant="agendabela-accent" size="lg">
-        <Link href="#teste-gratuitamente">Teste Gratuitamente</Link>
+        <Link
+          href="#teste-gratuitamente"
+          onClick={() =>
+            pushAgendaBelaMainEvent({
+              event: "lp_cta_clicked",
+              cta_position: "about",
+              cta_intent: "primary",
+            })
+          }
+        >
+          Teste Gratuitamente
+        </Link>
       </Button>
     </article>
   );

--- a/src/app/agendabela/automatize-seu-atendimento/components/form/form.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/form/form.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { useState, useEffect } from "react";
 import { SignupModal } from "../signup-modal";
 import { useAmplitude } from "@/contexts/AmplitudeProvider";
+import { pushAgendaBelaMainEvent } from "@/lib/analytics/dataLayer";
 
 export const FormComponent = () => {
   const [showSignupModal, setShowSignupModal] = useState(false);
@@ -32,6 +33,10 @@ export const FormComponent = () => {
     setEmail(emailValue);
     setInitialStep(1);
     track("agendabela/automatize-seu-atendimento/form_submission", { email: emailValue });
+    pushAgendaBelaMainEvent({
+      event: "lp_form_submitted",
+      form_name: "signup_initial",
+    });
     setShowSignupModal(true);
   };
 

--- a/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
@@ -14,6 +14,7 @@ import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { useCreateUser, useCreateBilling, useSendMagicLink } from "@/hooks/use-create-user";
 import { useAmplitude } from "@/contexts/AmplitudeProvider";
+import { pushAgendaBelaMainEvent } from "@/lib/analytics/dataLayer";
 import { Eye, EyeOff } from "lucide-react";
 
 const SESSION_KEY = "agendabela_signup_email";
@@ -174,6 +175,7 @@ export const SignupModal = ({ open, onOpenChange, initialEmail, initialStep = 1 
       {
         onSuccess: () => {
           track("agendabela/signup-modal/account_created", { email });
+          pushAgendaBelaMainEvent({ event: "lp_signup_completed" });
           // Persist email, name and phone so step 3 can validate context and send magic link
           sessionStorage.setItem(SESSION_KEY, email);
           sessionStorage.setItem(SESSION_NAME_KEY, name);

--- a/src/app/agendabela/automatize-seu-atendimento/components/testimonial/testimonial.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/testimonial/testimonial.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { pushAgendaBelaMainEvent } from "@/lib/analytics/dataLayer";
 
 export const TestimonialComponent = () => {
   return (
@@ -15,7 +18,18 @@ export const TestimonialComponent = () => {
         </p>
       </div>
       <Button asChild variant="agendabela-accent" size="lg">
-        <Link href="#teste-gratuitamente">Teste Gratuitamente</Link>
+        <Link
+          href="#teste-gratuitamente"
+          onClick={() =>
+            pushAgendaBelaMainEvent({
+              event: "lp_cta_clicked",
+              cta_position: "testimonial",
+              cta_intent: "primary",
+            })
+          }
+        >
+          Teste Gratuitamente
+        </Link>
       </Button>
     </div>
   );

--- a/src/lib/analytics/dataLayer.ts
+++ b/src/lib/analytics/dataLayer.ts
@@ -1,0 +1,66 @@
+/**
+ * Helper centralizado pra push de eventos no dataLayer do GTM.
+ *
+ * Schema padrão (todos os eventos de landing carregam product/landing_type/landing_slug
+ * pra distinguir entre produtos da Tudo Agenda e tipos de landing).
+ *
+ * Convenções:
+ * - Naming por intenção, não por visual (resiste a redesign).
+ * - Type-safe: TS bloqueia evento desconhecido ou parâmetro faltando.
+ *
+ * Doc: produtos/agenda-bela/medicao.md no companion-os.
+ */
+
+declare global {
+  interface Window {
+    dataLayer?: Record<string, unknown>[];
+  }
+}
+
+type CtaIntent = "primary" | "secondary";
+
+type LandingEvent =
+  | {
+      event: "lp_cta_clicked";
+      cta_position: string;
+      cta_intent: CtaIntent;
+    }
+  | {
+      event: "lp_form_submitted";
+      form_name: string;
+    }
+  | {
+      event: "lp_signup_completed";
+    };
+
+type LandingContext = {
+  product: string;
+  landing_type: "main" | "campaign";
+  landing_slug: string;
+};
+
+/**
+ * Faz push de um evento da landing principal do Agenda Bela.
+ * Componentes da landing principal usam `pushAgendaBelaMainEvent`.
+ * Outras landings/produtos no futuro: criar wrapper análogo.
+ */
+export function pushAgendaBelaMainEvent(eventData: LandingEvent): void {
+  pushLandingEvent(eventData, {
+    product: "agendabela",
+    landing_type: "main",
+    landing_slug: "automatize-seu-atendimento",
+  });
+}
+
+/**
+ * Push genérico — só usar em componentes que sabem o contexto deles.
+ * Componentes da landing principal devem usar pushAgendaBelaMainEvent.
+ */
+export function pushLandingEvent(
+  eventData: LandingEvent,
+  context: LandingContext,
+): void {
+  if (typeof window === "undefined") return;
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({ ...context, ...eventData });
+}


### PR DESCRIPTION
Adiciona dataLayer pushes pros 4 eventos canônicos Tier 2 da landing `/agendabela/automatize-seu-atendimento`. Sub-track 2.2 da Fase 2 do plano de medição.

## Mudanças

- Novo helper centralizado `src/lib/analytics/dataLayer.ts` — type-safe, schema padrão (`product`/`landing_type`/`landing_slug`) injetada automaticamente. Resiste a redesign futuro porque CTAs nomeados por **intenção/posição**, não por visual.
- 4 componentes atualizados pra disparar eventos:

| Componente | Evento | Parâmetros |
|---|---|---|
| `about/about.tsx` | `lp_cta_clicked` | cta_position: about, cta_intent: primary |
| `testimonial/testimonial.tsx` | `lp_cta_clicked` | cta_position: testimonial, cta_intent: primary |
| `form/form.tsx` | `lp_form_submitted` | form_name: signup_initial |
| `signup-modal/signup-modal.tsx` | `lp_signup_completed` | (no momento de account_created, ainda pré-pagamento) |

## Por que essa estrutura

- Quando vier outro SaaS ou landing de campanha, schema reusa sem mudança (basta criar nova função wrapper análoga a `pushAgendaBelaMainEvent`).
- Refatorar visual no redesign não quebra tracking (CTAs nomeados por posição, não por estilo).
- Type-safe: TS bloqueia evento desconhecido ou parâmetro faltando.

## Observações

- Pre-existing TS errors em `__tests__/*` e `hero.tsx` (assets) **não vêm desta PR**.
- `AboutComponent` e `TestimonialComponent` viraram client components (`"use client"`) pra suportar onClick — escolha simples; alternativa de wrapper extraído pode ser feita depois se outros CTAs surgirem.
- Mantemos o tracking do Amplitude já existente — GA4 e Amplitude têm papéis distintos (decisão registrada em ADR 0003).

## Validação após merge

Railway deploya automático. Daí:
1. Visita `tudoagenda.com.br/agendabela/automatize-seu-atendimento`
2. DevTools → Console → digita `window.dataLayer` — deve ter eventos
3. Clica em "Teste Gratuitamente" da seção About → vê `lp_cta_clicked` com cta_position 'about'
4. Submit do form → vê `lp_form_submitted`
5. Completa cadastro → vê `lp_signup_completed`

Triggers e tags GTM correspondentes serão configuradas via API (Iniesta) em paralelo.