### PR TITLE
feat(signup-modal): remove magic link client-side trigger e adiciona reenvio guarded

### DIFF
--- a/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/__tests__/signup-modal.test.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/__tests__/signup-modal.test.tsx
@@ -1,10 +1,9 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { SignupModal } from "../signup-modal";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AmplitudeProvider } from "@/contexts/AmplitudeProvider";
 import React from "react";
 
-// Mock sendMagicLink to track calls
 const mockSendMagicLink = jest.fn();
 let mockIsPending = false;
 
@@ -14,8 +13,7 @@ jest.mock("@/hooks/use-create-user", () => ({
     isPending: false,
   }),
   useCreateBilling: () => ({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    mutate: jest.fn((data: { email: string; name: string }, opts?: unknown) => {}),
+    mutate: jest.fn(),
     isPending: false,
   }),
   useSendMagicLink: () => ({
@@ -47,69 +45,77 @@ function renderModal(props: Partial<React.ComponentProps<typeof SignupModal>> = 
   );
 }
 
-describe("SignupModal step 3 flow", () => {
+describe("SignupModal step 3 — server-authoritative magic link", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsPending = false;
     sessionStorage.clear();
   });
 
-  it("sends magic link on mount when storedPhone exists", () => {
+  it("does NOT auto-send magic link on mount — the AbacatePay webhook is now the sole trigger", () => {
     sessionStorage.setItem("agendabela_signup_email", "test@test.com");
     sessionStorage.setItem("agendabela_signup_phone", "11999999999");
 
     renderModal();
+
+    expect(mockSendMagicLink).not.toHaveBeenCalled();
+  });
+
+  it("shows the 'aguarde 1 min no WhatsApp' copy when phone is present", () => {
+    sessionStorage.setItem("agendabela_signup_email", "test@test.com");
+    sessionStorage.setItem("agendabela_signup_phone", "11999999999");
+
+    renderModal();
+
+    expect(
+      screen.getByText(/Pagamento confirmado/i),
+    ).toBeInTheDocument();
+    // Texto quebrado por <strong>1 minuto</strong> — limita o matcher ao
+    // <p> que contém a frase, evitando os ancestrais.
+    const paragraphs = screen.getAllByText((_, node) => {
+      if (!node) return false;
+      if (node.tagName !== "P") return false;
+      const text = node.textContent ?? "";
+      return text.includes("receber no") && text.includes("WhatsApp");
+    });
+    expect(paragraphs.length).toBeGreaterThan(0);
+  });
+
+  it("shows fallback CTA to download app when phone is missing", () => {
+    sessionStorage.setItem("agendabela_signup_email", "test@test.com");
+
+    renderModal();
+
+    expect(
+      screen.getByText(/Baixe o app abaixo e faça login com seu email/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Reenviar link' button when phone is present and triggers sendMagicLink on tap", () => {
+    sessionStorage.setItem("agendabela_signup_email", "test@test.com");
+    sessionStorage.setItem("agendabela_signup_phone", "11999999999");
+
+    renderModal();
+
+    const resendBtn = screen.getByRole("button", {
+      name: /Reenviar link/i,
+    });
+    fireEvent.click(resendBtn);
 
     expect(mockSendMagicLink).toHaveBeenCalledTimes(1);
     expect(mockSendMagicLink).toHaveBeenCalledWith(
       { phone: "11999999999", email: "test@test.com" },
-      expect.objectContaining({ onError: expect.any(Function) })
+      expect.objectContaining({ onError: expect.any(Function) }),
     );
-    // Verify dedup flag was set
-    expect(sessionStorage.getItem("agendabela_magic_link_sent")).toBe("1");
   });
 
-  it("does not send duplicate magic link on re-render", () => {
+  it("does NOT render the 'Reenviar' button when phone is missing", () => {
     sessionStorage.setItem("agendabela_signup_email", "test@test.com");
-    sessionStorage.setItem("agendabela_signup_phone", "11999999999");
-    sessionStorage.setItem("agendabela_magic_link_sent", "1");
 
     renderModal();
 
-    expect(mockSendMagicLink).not.toHaveBeenCalled();
-  });
-
-  it("shows error state on failure", async () => {
-    sessionStorage.setItem("agendabela_signup_email", "test@test.com");
-    sessionStorage.setItem("agendabela_signup_phone", "11999999999");
-
-    // Capture the onError callback and call it
-    mockSendMagicLink.mockImplementation((_data: unknown, opts: { onError: () => void }) => {
-      opts.onError();
-    });
-
-    renderModal();
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(/Não conseguimos enviar o link/i)
-      ).toBeInTheDocument();
-    });
-  });
-
-  it("shows fallback message when no storedPhone", () => {
-    sessionStorage.setItem("agendabela_signup_email", "test@test.com");
-    // No phone stored
-
-    renderModal();
-
-    expect(mockSendMagicLink).not.toHaveBeenCalled();
     expect(
-      screen.getByText(/Conta criada! Baixe o app e faça login:/i)
-    ).toBeInTheDocument();
-    // Should NOT show WhatsApp claim
-    expect(
-      screen.queryByText(/Enviamos um link pro seu WhatsApp/i)
+      screen.queryByRole("button", { name: /Reenviar link/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
@@ -20,7 +20,6 @@ import { Eye, EyeOff } from "lucide-react";
 const SESSION_KEY = "agendabela_signup_email";
 const SESSION_NAME_KEY = "agendabela_signup_name";
 const SESSION_PHONE_KEY = "agendabela_signup_phone";
-const SESSION_MAGIC_LINK_SENT = "agendabela_magic_link_sent";
 
 // Note: No CPF field needed — AbacatePay v2 only requires email for customer.
 
@@ -88,18 +87,14 @@ export const SignupModal = ({ open, onOpenChange, initialEmail, initialStep = 1 
       } else {
         setEmail(storedEmail);
         setStep(3);
-        // Send magic link after payment success (only once per session)
         if (!storedPhone) {
           setNoPhone(true);
-        } else if (!sessionStorage.getItem(SESSION_MAGIC_LINK_SENT)) {
-          sessionStorage.setItem(SESSION_MAGIC_LINK_SENT, "1");
-          sendMagicLink(
-            { phone: storedPhone, email: storedEmail },
-            {
-              onError: () => setMagicLinkError(true),
-            }
-          );
         }
+        // Magic link is now dispatched server-side by the AbacatePay
+        // webhook (backend PR #65). Step 3 just informs the user it's
+        // coming via WhatsApp; the "Reenviar link" button below can
+        // request a resend through the public endpoint, which only
+        // succeeds for subscriptions already marked ACTIVE.
       }
     }
   }, [initialStep]);
@@ -134,7 +129,6 @@ export const SignupModal = ({ open, onOpenChange, initialEmail, initialStep = 1 
       sessionStorage.removeItem(SESSION_KEY);
       sessionStorage.removeItem(SESSION_NAME_KEY);
       sessionStorage.removeItem(SESSION_PHONE_KEY);
-      sessionStorage.removeItem(SESSION_MAGIC_LINK_SENT);
     }
     onOpenChange(nextOpen);
   };
@@ -418,55 +412,71 @@ export const SignupModal = ({ open, onOpenChange, initialEmail, initialStep = 1 
           <>
             <AlertDialogHeader>
               <AlertDialogTitle className="text-xl text-center">
-                {isSendingLink ? "Enviando link..." : "Conta criada! 🎉"}
+                Pagamento confirmado! 🎉
               </AlertDialogTitle>
               <AlertDialogDescription asChild>
                 <div className="space-y-4 text-center">
-                  {isSendingLink && (
-                    <div className="flex justify-center py-4">
-                      <Spinner size="md" variant="primary" />
-                    </div>
+                  {noPhone ? (
+                    <p>
+                      Sua conta está pronta! Baixe o app abaixo e faça login com seu email.
+                    </p>
+                  ) : (
+                    <p>
+                      Em até <strong>1 minuto</strong> você vai receber no
+                      WhatsApp o link para abrir o app Meu Salão.
+                      <br />
+                      <br />
+                      Se ainda não tem o app instalado, baixe primeiro pelos
+                      botões abaixo e depois toque no link do WhatsApp.
+                    </p>
                   )}
-                  {magicLinkError && (
-                    <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-md p-3">
-                      Não conseguimos enviar o link. Baixe o app e faça login manualmente.
-                    </div>
-                  )}
-                  {!isSendingLink && !magicLinkError && (
-                    <>
-                      {noPhone ? (
-                        <p>
-                          Conta criada! Baixe o app e faça login:
-                        </p>
-                      ) : (
-                        <p>
-                          Enviamos um link pro seu WhatsApp.
-                          <br />
-                          <strong>Toque nele pra abrir o app!</strong>
-                        </p>
-                      )}
 
-                      <div className="bg-purple-50 p-3 rounded-lg text-sm">
-                        <p className="font-medium mb-2">{noPhone ? "Baixe o app:" : "Não recebeu? Baixe o app e faça login:"}</p>
-                        <div className="flex gap-3 justify-center">
-                          <a
-                            href="https://apps.apple.com/app/agenda-bela"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline text-purple-700"
-                          >
-                            📱 App Store
-                          </a>
-                          <a
-                            href="https://play.google.com/store/apps/details?id=com.agendabela"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline text-purple-700"
-                          >
-                            🤖 Google Play
-                          </a>
+                  <div className="bg-purple-50 p-3 rounded-lg text-sm">
+                    <p className="font-medium mb-2">Baixe o app Meu Salão:</p>
+                    <div className="flex gap-3 justify-center">
+                      <a
+                        href="https://apps.apple.com/app/agenda-bela"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline text-purple-700"
+                      >
+                        📱 App Store
+                      </a>
+                      <a
+                        href="https://play.google.com/store/apps/details?id=com.tudoagenda.agendabela"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline text-purple-700"
+                      >
+                        🤖 Google Play
+                      </a>
+                    </div>
+                  </div>
+
+                  {!noPhone && (
+                    <>
+                      {magicLinkError && (
+                        <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-md p-3">
+                          Não conseguimos reenviar o link. Tente de novo em alguns minutos.
                         </div>
-                      </div>
+                      )}
+                      <button
+                        type="button"
+                        disabled={isSendingLink}
+                        onClick={() => {
+                          const storedPhone = sessionStorage.getItem(SESSION_PHONE_KEY);
+                          const storedEmail = sessionStorage.getItem(SESSION_KEY);
+                          if (!storedPhone || !storedEmail) return;
+                          setMagicLinkError(false);
+                          sendMagicLink(
+                            { phone: storedPhone, email: storedEmail },
+                            { onError: () => setMagicLinkError(true) },
+                          );
+                        }}
+                        className="text-sm text-purple-700 underline disabled:opacity-50"
+                      >
+                        {isSendingLink ? "Reenviando..." : "Não recebeu? Reenviar link"}
+                      </button>
                     </>
                   )}
                 </div>
@@ -476,7 +486,6 @@ export const SignupModal = ({ open, onOpenChange, initialEmail, initialStep = 1 
             <AlertDialogFooter className="flex-col gap-2 pt-2">
               <Button
                 onClick={() => handleOpenChange(false)}
-                disabled={isSendingLink}
                 className="w-full bg-[#673ab7] hover:bg-[#5e35b1] text-white"
               >
                 Fechar


### PR DESCRIPTION
## Contexto — Issue tudoagenda/agendabela-mobile-app#149 (parte LP)

Acompanha o PR backend tudoagenda/agendabela-backend-services#65 (mergeado) e o PR mobile tudoagenda/agendabela-mobile-app#152 (mergeado). Fecha o loop da migration de magic link timing.

## Bug que resolve

O step 3 do signup-modal disparava `sendMagicLink` no mount logo apos detectar `searchParams` de payment success — mas o guard era client-side via `sessionStorage` flag, frivolo de bypassar (refresh na URL de sucesso, voltar/avancar no navegador, etc). Resultado: magic link chegava no WhatsApp antes do pagamento ser realmente confirmado.

## Fix — backend autoritativo

O backend agora envia o magic link a partir do webhook AbacatePay nos handlers de sucesso (PR backend #65). Esta LP nao dispara mais magic link no auto-mount.

## Mudancas no signup-modal

- Remove `sendMagicLink(...)` automatico ao entrar no step 3 (responsabilidade migrou pro webhook)
- Remove flag `SESSION_MAGIC_LINK_SENT` (sem-uso)
- Step 3 copy atualizada: "Pagamento confirmado! Em ate 1 minuto voce vai receber no WhatsApp..."
- Botao "Nao recebeu? Reenviar link" novo — chama `useSendMagicLink` manualmente. O backend agora exige `subscriptionStatus = ACTIVE` no endpoint publico, entao reenvio so funciona apos pagamento real (mesmo que user spame o botao)
- Quando `noPhone === true` (signup sem WhatsApp), fluxo fallback: "baixe app e faca login com email"
- Link Google Play corrigido (`com.agendabela` → `com.tudoagenda.agendabela`, o package real)

## Tests (5/5 verde)

Spec atualizado pra refletir nova logica:
- NAO auto-dispara magic link no mount
- Mostra copy "em ate 1 minuto WhatsApp" quando phone presente
- Mostra fallback CTA quando phone ausente
- Botao "Reenviar" chama sendMagicLink ao tap
- Botao "Reenviar" nao renderiza sem phone

## Definition of done

- [x] Sem chamada automatica de magic link em mount do step 3
- [x] Copy atualizada "em ate 1 min no WhatsApp"
- [x] Botao reenvio funcional
- [x] Tests verde
- [ ] Apos merge: testar fluxo LP → AbacatePay checkout → step 3 aparece copy nova, magic link chega via webhook (depende DNS + Railway custom domain do PR backend estar configurado)