### PR TITLE
feat(signup-modal): badges oficiais App Store/Play com device detection

### DIFF
--- a/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
+import { AppStoreBadges } from "@/components/app-store-badges/app-store-badges";
 import { useCreateUser, useCreateBilling, useSendMagicLink } from "@/hooks/use-create-user";
 import { useAmplitude } from "@/contexts/AmplitudeProvider";
 import { pushAgendaBelaMainEvent } from "@/lib/analytics/dataLayer";
@@ -431,27 +432,7 @@ export const SignupModal = ({ open, onOpenChange, initialEmail, initialStep = 1 
                     </p>
                   )}
 
-                  <div className="bg-purple-50 p-3 rounded-lg text-sm">
-                    <p className="font-medium mb-2">Baixe o app Meu Salão:</p>
-                    <div className="flex gap-3 justify-center">
-                      <a
-                        href="https://apps.apple.com/app/agenda-bela"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="underline text-purple-700"
-                      >
-                        📱 App Store
-                      </a>
-                      <a
-                        href="https://play.google.com/store/apps/details?id=com.tudoagenda.agendabela"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="underline text-purple-700"
-                      >
-                        🤖 Google Play
-                      </a>
-                    </div>
-                  </div>
+                  <AppStoreBadges heading="Baixe o app Meu Salão:" />
 
                   {!noPhone && (
                     <>

--- a/src/components/app-store-badges/__tests__/app-store-badges.test.tsx
+++ b/src/components/app-store-badges/__tests__/app-store-badges.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import { AppStoreBadges } from "../app-store-badges";
+
+describe("AppStoreBadges — device detection", () => {
+  describe("with forced platform (test override)", () => {
+    it("renders only Apple badge for iOS", () => {
+      render(<AppStoreBadges forcePlatform="ios" />);
+
+      expect(
+        screen.getByAltText("Baixar na App Store"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByAltText("Disponível no Google Play"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders only Google badge for Android", () => {
+      render(<AppStoreBadges forcePlatform="android" />);
+
+      expect(
+        screen.getByAltText("Disponível no Google Play"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByAltText("Baixar na App Store"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders BOTH badges + desktop hint for desktop", () => {
+      render(<AppStoreBadges forcePlatform="desktop" />);
+
+      expect(screen.getByAltText("Baixar na App Store")).toBeInTheDocument();
+      expect(
+        screen.getByAltText("Disponível no Google Play"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/abra esta página no seu dispositivo móvel/i),
+      ).toBeInTheDocument();
+    });
+
+    it("respects custom heading prop", () => {
+      render(
+        <AppStoreBadges
+          forcePlatform="desktop"
+          heading="Heading customizado"
+        />,
+      );
+
+      expect(screen.getByText("Heading customizado")).toBeInTheDocument();
+    });
+  });
+
+  describe("with auto-detection (User-Agent based)", () => {
+    const originalUA = navigator.userAgent;
+
+    function setUA(ua: string) {
+      Object.defineProperty(navigator, "userAgent", {
+        value: ua,
+        configurable: true,
+      });
+    }
+
+    afterEach(() => {
+      setUA(originalUA);
+    });
+
+    it("detects iOS from iPhone UA", () => {
+      setUA(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+      );
+      render(<AppStoreBadges />);
+
+      expect(
+        screen.getByAltText("Baixar na App Store"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByAltText("Disponível no Google Play"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("detects Android from Android UA", () => {
+      setUA(
+        "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36",
+      );
+      render(<AppStoreBadges />);
+
+      expect(
+        screen.getByAltText("Disponível no Google Play"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByAltText("Baixar na App Store"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("falls back to desktop (both badges) when UA doesn't match mobile", () => {
+      setUA(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120",
+      );
+      render(<AppStoreBadges />);
+
+      expect(screen.getByAltText("Baixar na App Store")).toBeInTheDocument();
+      expect(
+        screen.getByAltText("Disponível no Google Play"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/app-store-badges/app-store-badges.tsx
+++ b/src/components/app-store-badges/app-store-badges.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Platform = "ios" | "android" | "desktop" | "unknown";
+
+/**
+ * Detecta a plataforma a partir do User-Agent atual do navegador.
+ * Client-only — sempre rodar dentro de useEffect ou após mount.
+ */
+function detectPlatform(): Platform {
+  if (typeof navigator === "undefined") return "unknown";
+  const ua = navigator.userAgent;
+  if (/iPhone|iPad|iPod/i.test(ua)) return "ios";
+  if (/Android/i.test(ua)) return "android";
+  return "desktop";
+}
+
+/**
+ * URLs default — apontam pra TestFlight enquanto pré-launch. Quando o app
+ * estiver listado nas lojas públicas, basta atualizar as env vars
+ * `NEXT_PUBLIC_APP_STORE_URL` e `NEXT_PUBLIC_PLAY_STORE_URL` sem code
+ * change.
+ */
+const DEFAULT_IOS_URL =
+  process.env.NEXT_PUBLIC_APP_STORE_URL ??
+  "https://testflight.apple.com/join/PLACEHOLDER";
+const DEFAULT_ANDROID_URL =
+  process.env.NEXT_PUBLIC_PLAY_STORE_URL ??
+  "https://play.google.com/store/apps/details?id=com.tudoagenda.agendabela";
+
+interface AppStoreBadgesProps {
+  /**
+   * Tom textual mostrado acima dos badges. Em desktop, override automático
+   * pra um QR code ainda mostrará esse título.
+   */
+  heading?: string;
+  /**
+   * Force a platform to render — útil em tests ou previews. Quando ausente,
+   * detecta via User-Agent no client.
+   */
+  forcePlatform?: Platform;
+  className?: string;
+}
+
+/**
+ * Renderiza badges oficiais Apple App Store / Google Play conforme a
+ * plataforma do usuário. iOS-only mostra só Apple; Android-only só Google;
+ * desktop mostra ambos. Os badges seguem as guidelines oficiais (proporção,
+ * altura mínima, sem alterar cores).
+ *
+ * - Apple Marketing Resources: https://developer.apple.com/app-store/marketing/guidelines/
+ * - Google Brand Guidelines: https://play.google.com/intl/en_us/badges/
+ */
+export function AppStoreBadges({
+  heading = "Baixe o app Meu Salão:",
+  forcePlatform,
+  className,
+}: AppStoreBadgesProps) {
+  const [platform, setPlatform] = useState<Platform>(
+    forcePlatform ?? "unknown",
+  );
+
+  useEffect(() => {
+    if (forcePlatform) {
+      setPlatform(forcePlatform);
+      return;
+    }
+    setPlatform(detectPlatform());
+  }, [forcePlatform]);
+
+  if (platform === "unknown") {
+    // Pré-mount: render nothing pra evitar flash de FOUC entre layouts iOS/Android/desktop.
+    return null;
+  }
+
+  const showIOS = platform === "ios" || platform === "desktop";
+  const showAndroid = platform === "android" || platform === "desktop";
+
+  return (
+    <div className={className ?? "bg-purple-50 p-4 rounded-lg text-center"}>
+      <p className="font-medium text-sm mb-3">{heading}</p>
+      <div className="flex gap-2 justify-center items-center flex-wrap">
+        {showIOS && (
+          <a
+            href={DEFAULT_IOS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block"
+            aria-label="Baixar na App Store"
+          >
+            {/* Apple-fornecido SVG, hospedado por eles — sempre atualizado */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg"
+              alt="Baixar na App Store"
+              height={48}
+              style={{ height: 48, width: "auto" }}
+            />
+          </a>
+        )}
+        {showAndroid && (
+          <a
+            href={DEFAULT_ANDROID_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block"
+            aria-label="Disponível no Google Play"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="https://play.google.com/intl/en_us/badges/static/images/badges/pt-br_badge_web_generic.png"
+              alt="Disponível no Google Play"
+              height={64}
+              style={{ height: 64, width: "auto" }}
+            />
+          </a>
+        )}
+      </div>
+      {platform === "desktop" && (
+        <p className="text-xs text-gray-500 mt-3">
+          Para baixar pelo celular, abra esta página no seu dispositivo móvel.
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Contexto — Issue tudoagenda/agendabela-mobile-app#150

Substitui os links App Store/Play Store do step 3 do signup-modal por badges oficiais Apple/Google com device detection.

## Componente novo

`src/components/app-store-badges/app-store-badges.tsx`:
- Detecta plataforma via `navigator.userAgent` no useEffect
- iOS → só Apple badge (SVG oficial)
- Android → só Google badge (PNG oficial PT-BR)
- Desktop → ambos + hint
- Pre-mount: render null (anti-flash)

## URLs configuráveis via env

- `NEXT_PUBLIC_APP_STORE_URL` (TestFlight enquanto pré-launch)
- `NEXT_PUBLIC_PLAY_STORE_URL`

## Tests (12/12 verde)

- 7 novos pro AppStoreBadges (force iOS/Android/desktop, auto-detect UAs)
- 5 do signup-modal continuam verde

## Pre-reqs

- Miguel setar env vars no Railway service da LP.