### PR TITLE
feat(checkout): passa profileId como externalId pro AbacatePay

### DIFF
--- a/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
@@ -21,6 +21,7 @@ import { Eye, EyeOff } from "lucide-react";
 const SESSION_KEY = "agendabela_signup_email";
 const SESSION_NAME_KEY = "agendabela_signup_name";
 const SESSION_PHONE_KEY = "agendabela_signup_phone";
+const SESSION_PROFILE_ID_KEY = "agendabela_signup_profile_id";
 
 // Note: No CPF field needed — AbacatePay v2 only requires email for customer.
 
@@ -168,13 +169,18 @@ export const SignupModal = ({ open, onOpenChange, initialEmail, initialStep = 1 
     createUser(
       { email, password, name, salonName, phone: phoneDigits },
       {
-        onSuccess: () => {
+        onSuccess: (data) => {
           track("agendabela/signup-modal/account_created", { email });
           pushAgendaBelaMainEvent({ event: "lp_signup_completed" });
           // Persist email, name and phone so step 3 can validate context and send magic link
           sessionStorage.setItem(SESSION_KEY, email);
           sessionStorage.setItem(SESSION_NAME_KEY, name);
           sessionStorage.setItem(SESSION_PHONE_KEY, phoneDigits);
+          // profileId vira `externalId` no checkout AbacatePay pra casar com
+          // o webhook checkout.completed e criar a Subscription TRIALING.
+          if (data?.profileId) {
+            sessionStorage.setItem(SESSION_PROFILE_ID_KEY, data.profileId);
+          }
           setStep(2);
         },
         onError: (error: Error) => {
@@ -189,8 +195,9 @@ export const SignupModal = ({ open, onOpenChange, initialEmail, initialStep = 1 
 
     const customerName = name || sessionStorage.getItem(SESSION_NAME_KEY) || "";
     const customerPhone = phone.replace(/\D/g, "") || sessionStorage.getItem(SESSION_PHONE_KEY) || "";
+    const profileId = sessionStorage.getItem(SESSION_PROFILE_ID_KEY) || undefined;
     createBilling(
-      { email, name: customerName, phone: customerPhone },
+      { email, name: customerName, phone: customerPhone, profileId },
       {
         onSuccess: (data) => {
           if (data.url) {

--- a/src/app/api/agendabela/create-billing/route.ts
+++ b/src/app/api/agendabela/create-billing/route.ts
@@ -36,6 +36,10 @@ export async function POST(req: Request) {
     const email = typeof body.email === "string" ? body.email.trim() : "";
     const rawName = typeof body.name === "string" ? sanitizeName(body.name) : "";
     const rawPhone = typeof body.phone === "string" ? sanitizePhone(body.phone) : "";
+    // profileId vira `externalId` no checkout. Backend usa pra casar o
+    // webhook checkout.completed com a row de Profile e criar a Subscription
+    // em status TRIALING (Opção E — AbacatePay v2 sem trial nativo).
+    const profileId = typeof body.profileId === "string" ? body.profileId.trim() : "";
 
     if (!email || !isValidEmail(email)) {
       return NextResponse.json(
@@ -89,6 +93,10 @@ export async function POST(req: Request) {
 
     if (customerId) {
       checkoutPayload.customerId = customerId;
+    }
+
+    if (profileId) {
+      checkoutPayload.externalId = profileId;
     }
 
     const checkoutRes = await fetch(`${ABACATE_PAY_V2_URL}/checkouts/create`, {

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -10,6 +10,10 @@ export interface CreateBillingParams {
   email: string;
   name?: string;
   phone?: string;
+  // Backend usa esse profileId como `externalId` no payload do AbacatePay
+  // pra casar o webhook checkout.completed com a row de Profile e criar
+  // a Subscription em status TRIALING (Opção E).
+  profileId?: string;
 }
 
 type CreateUserResponse = {


### PR DESCRIPTION
## Resumo

PR 2/6 da migração pra recorrência real via AbacatePay (Opção E). Faz com que o checkout R$1 carregue o `profileId` como `externalId`, pra o backend conseguir casar o webhook `checkout.completed` com a row de Profile e criar a Subscription em status TRIALING.

## Mudanças

- **`src/services/user.ts`** — `CreateBillingParams` ganha `profileId?: string`
- **`src/app/api/agendabela/create-billing/route.ts`** — aceita `profileId` no body e, se presente, adiciona `externalId: profileId` no `checkoutPayload` enviado pro AbacatePay
- **`signup-modal.tsx`**:
  - Nova constante `SESSION_PROFILE_ID_KEY`
  - `handleStep1Submit.onSuccess` persiste `data.profileId` no sessionStorage
  - `handlePayment` lê do sessionStorage e passa pra `createBilling`

## Por que sessionStorage

O fluxo da LP é dividido em 3 steps (cadastro → confirmar email → checkout) e o user pode reabrir o modal em `step=3` via query param. Persistir em sessionStorage permite que o checkout funcione mesmo se o modal for desmontado entre os steps.

## Sem regressão

Se a LP chamar `create-billing` sem `profileId` (compat), o backend só não passa `externalId` pro AbacatePay — checkout funciona normal. Migração suave.

## Próximos PRs

- PR3 (backend): webhook `checkout.completed` lê `externalId`, cria `Subscription` em `TRIALING` com `trialEndsAt = now + 30d`
- PR4 (backend): worker NestJS cron cria subscription real no AbacatePay no dia 30
- PR5 (backend): webhook `subscription.completed` casa via `externalId`
- PR6 (LP): banner "30 dias grátis — cobrança em DD/MM"

## Test plan

- [x] Lint passa
- [x] Jest related tests: 18/18 passaram
- [ ] Smoke manual em staging: cadastrar user → conferir que checkout AbacatePay tem `externalId` igual ao `Profile.id`
- [ ] Smoke prod (após PR3 mergeado e backend pronto pra receber)