### PR TITLE
feat(lp): banner '30 dias grátis' no step 3 pós-pagamento

### DIFF
--- a/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
@@ -41,6 +41,21 @@ function formatPhone(value: string): string {
   return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
 }
 
+/**
+ * Calcula a data de término do trial (now + 30 dias) e retorna formatada
+ * em pt-BR. O cálculo é feito no momento da renderização do step 3
+ * (logo após o pagamento) — mesma janela do `trialEndsAt` que o backend
+ * grava em Subscription. Aceitamos pequena divergência (segundos) entre
+ * o que o user vê e o que está no banco.
+ */
+function formatTrialEndDate(now: Date = new Date()): string {
+  const end = new Date(now);
+  end.setDate(end.getDate() + 30);
+  const day = String(end.getDate()).padStart(2, "0");
+  const month = String(end.getMonth() + 1).padStart(2, "0");
+  return `${day}/${month}`;
+}
+
 function validatePassword(pw: string): string | null {
   if (pw.length < 8) return "Mínimo 8 caracteres";
   if (!/[A-Z]/.test(pw)) return "Precisa de letra maiúscula";
@@ -424,6 +439,17 @@ export const SignupModal = ({ open, onOpenChange, initialEmail, initialStep = 1 
               </AlertDialogTitle>
               <AlertDialogDescription asChild>
                 <div className="space-y-4 text-center">
+                  <div className="rounded-md bg-purple-50 border border-purple-200 text-purple-900 text-sm p-3 text-left">
+                    <p className="font-semibold">
+                      30 dias grátis começam agora.
+                    </p>
+                    <p className="mt-1">
+                      Primeira cobrança automática em{" "}
+                      <strong>{formatTrialEndDate()}</strong> de R$ 59,90/mês.
+                      Cancele quando quiser pelo perfil.
+                    </p>
+                  </div>
+
                   {noPhone ? (
                     <p>
                       Sua conta está pronta! Baixe o app abaixo e faça login com seu email.


### PR DESCRIPTION
## Resumo

PR 6/6 (último) da migração pra recorrência real via AbacatePay (Opção E). Adiciona banner no step 3 do `signup-modal` (tela pós-pagamento confirmado) deixando claro pro user que entrou em trial de 30 dias e quando virá a primeira cobrança real.

## Mudança

No step 3 do `signup-modal.tsx`, antes da mensagem "Em até 1 minuto receberá WhatsApp...", aparece:

> **30 dias grátis começam agora.**
> Primeira cobrança automática em **DD/MM** de R$ 59,90/mês. Cancele quando quiser pelo perfil.

Helper `formatTrialEndDate()` calcula `now + 30 dias` no momento da renderização (mesma janela do `trialEndsAt` que o backend grava em Subscription).

## Por que aqui

- É a primeira tela que o user vê após o pagamento confirmar — ponto de máxima atenção
- Reduz ansiedade ("vou ser cobrado de novo?") e estabelece expectativa clara
- Reforça caminho de cancelamento ("pelo perfil") — alinha com Apple/Play que exigem caminho explícito
- Funciona pra ambos os fluxos (com e sem WhatsApp)

## Encadeamento da Opção E — agora 100% completa do lado de engenharia

```
1. LP — user cadastra, paga R$1 (externalId=profileId)               [✅ #42]
2. Webhook checkout.completed → cria Subscription TRIALING            [✅ #68]
3. Step 3 mostra banner "30 dias grátis até DD/MM"                    [⏳ este PR]
4. 30 dias depois: worker chama /subscriptions/create na AbacatePay   [✅ #69]
5. Webhook subscription.completed → migra TRIALING → ACTIVE           [✅ #71]
6. AbacatePay agenda renovações mensais automaticamente
```

## Test plan

- [x] Lint passa
- [x] 10 tests passam (Jest related — sem regressão)
- [ ] Smoke manual: completar fluxo de cadastro até step 3 e conferir o texto do banner com data correta

## Notas

- A data exibida pode divergir do `Subscription.trialEndsAt` por alguns segundos (rendering vs webhook timing). Aceitável — `formatTrialEndDate` é só dia/mês.
- Não precisa de tradução agora — produto é só pt-BR.