### PR TITLE
feat(reativacao): LP pública /agendabela/reativar — fluxo card-first base legado

### DIFF
--- a/src/app/agendabela/reativar/layout.tsx
+++ b/src/app/agendabela/reativar/layout.tsx
@@ -1,0 +1,41 @@
+import { Metadata } from "next";
+
+const pageUrl = "https://tudoagenda.com.br/agendabela/reativar";
+const title = "Reative sua conta | Agenda Bela";
+const description =
+  "O Agenda Bela agora virou app. Reative sua conta, mantenha seus dados antigos e teste grátis por 30 dias. Você não será cobrada hoje.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: "/agendabela/reativar",
+  },
+  robots: {
+    index: false, // LP de campanha — não indexar
+  },
+  openGraph: {
+    type: "website",
+    locale: "pt_BR",
+    url: pageUrl,
+    siteName: "Agenda Bela",
+    title,
+    description,
+    images: [
+      {
+        url: "/brand/agenda-bela/social-preview.png",
+        width: 1200,
+        height: 630,
+        alt: "Agenda Bela — Reative sua conta",
+      },
+    ],
+  },
+};
+
+export default function Layout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/src/app/agendabela/reativar/page.tsx
+++ b/src/app/agendabela/reativar/page.tsx
@@ -1,0 +1,5 @@
+import { ReactivationFlow } from "./reactivation-flow";
+
+export default function ReativarPage() {
+  return <ReactivationFlow />;
+}

--- a/src/app/agendabela/reativar/reactivation-flow.tsx
+++ b/src/app/agendabela/reativar/reactivation-flow.tsx
@@ -1,0 +1,731 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useState, useEffect } from "react";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useReactivationLookup, useReactivationStart } from "@/hooks/use-reactivation";
+import {
+  pushAgendaBelaReativacaoEvent,
+} from "@/lib/analytics/dataLayer";
+import type { ReactivationLookupResponse } from "@/services/reactivation";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validatePassword(pw: string): string | null {
+  if (pw.length < 8) return "Mínimo 8 caracteres";
+  if (!/[A-Z]/.test(pw)) return "Precisa de letra maiúscula";
+  if (!/[a-z]/.test(pw)) return "Precisa de letra minúscula";
+  if (!/[0-9]/.test(pw)) return "Precisa de número";
+  if (!/[^A-Za-z0-9]/.test(pw)) return "Precisa de caractere especial (!@#$...)";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Tipos de step
+// ---------------------------------------------------------------------------
+
+type Step =
+  | "lookup"        // Usuária informa email/WhatsApp
+  | "confirm"       // Mostra dados mascarados e pede nova senha
+  | "redirecting"   // Redirecionando para AbacatePay
+  | "success"       // Tela pós-checkout (volta com ?reactivation=success)
+  | "already_active"
+  | "new_signup_required"
+  | "token_expired"
+  | "error";
+
+// ---------------------------------------------------------------------------
+// Componente principal
+// ---------------------------------------------------------------------------
+
+export function ReactivationFlow() {
+  const [step, setStep] = useState<Step>("lookup");
+  const [identifier, setIdentifier] = useState("");
+  const [identifierError, setIdentifierError] = useState<string | null>(null);
+  const [lookupResult, setLookupResult] = useState<ReactivationLookupResponse | null>(null);
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
+  const [generalError, setGeneralError] = useState<string | null>(null);
+
+  const lookup = useReactivationLookup();
+  const startReactivation = useReactivationStart();
+
+  // Detecta volta do AbacatePay com ?reactivation=success
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("reactivation") === "success") {
+      setStep("success");
+      const url = new URL(window.location.href);
+      url.searchParams.delete("reactivation");
+      window.history.replaceState({}, "", url.pathname);
+    }
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  function handleLookupSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setIdentifierError(null);
+    setGeneralError(null);
+
+    const value = identifier.trim();
+    if (!value) {
+      setIdentifierError("Informe seu email ou WhatsApp.");
+      return;
+    }
+
+    lookup.mutate(value, {
+      onSuccess: (data) => {
+        setLookupResult(data);
+
+        if (data.status === "ALREADY_ACTIVE") {
+          setStep("already_active");
+          return;
+        }
+
+        if (data.status === "NEW_SIGNUP_REQUIRED") {
+          setStep("new_signup_required");
+          return;
+        }
+
+        // LEGACY_INACTIVE — mostra confirmação + dispara paywall_viewed
+        setStep("confirm");
+        pushAgendaBelaReativacaoEvent({
+          event: "paywall_viewed",
+          flow: "reactivation",
+          landing_slug: "reativacao",
+        });
+      },
+      onError: (err) => {
+        setGeneralError(err.message ?? "Erro ao buscar conta. Tente novamente.");
+      },
+    });
+  }
+
+  function handleConfirmSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setPasswordError(null);
+    setConfirmError(null);
+    setGeneralError(null);
+
+    const pwErr = validatePassword(password);
+    if (pwErr) {
+      setPasswordError(pwErr);
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setConfirmError("As senhas não coincidem.");
+      return;
+    }
+
+    if (!lookupResult?.lookupToken) {
+      setGeneralError("Sessão perdida. Reinicie o processo.");
+      setStep("lookup");
+      return;
+    }
+
+    // Dispara checkout_opened antes de redirecionar
+    pushAgendaBelaReativacaoEvent({
+      event: "checkout_opened",
+      flow: "reactivation",
+      source: "lp_reactivation",
+    });
+
+    startReactivation.mutate(
+      { lookupToken: lookupResult.lookupToken, newPassword: password },
+      {
+        onSuccess: (data) => {
+          setStep("redirecting");
+          window.location.href = data.checkoutUrl;
+        },
+        onError: (err) => {
+          if (err.code === "TOKEN_EXPIRED" || err.status === 410) {
+            setStep("token_expired");
+            return;
+          }
+          setGeneralError(
+            err.message ?? "Erro ao iniciar pagamento. Tente novamente.",
+          );
+        },
+      },
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div className="min-h-dvh bg-surface-subtle flex flex-col">
+      {/* Header */}
+      <header className="px-5 pt-6 pb-4 flex items-center justify-between max-w-lg mx-auto w-full">
+        <Image
+          src="/brand/logo-app.png"
+          alt="Agenda Bela"
+          width={56}
+          height={56}
+          priority
+          className="h-12 w-12"
+        />
+        <span className="font-mono-brand text-[10px] tracking-[2px] uppercase text-brand-vinho">
+          por Tudo Agenda
+        </span>
+      </header>
+
+      {/* Conteúdo principal */}
+      <main className="flex-1 flex flex-col items-center justify-start px-5 pb-16 max-w-lg mx-auto w-full">
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Step: lookup                                                         */}
+        {/* ------------------------------------------------------------------ */}
+        {step === "lookup" && (
+          <div className="w-full space-y-6">
+            {/* Chamada emocional */}
+            <div className="space-y-2 pt-4">
+              <span className="font-mono-brand text-[11px] tracking-[2px] uppercase text-brand-vinho">
+                Reative sua conta
+              </span>
+              <h1 className="font-fraunces italic font-normal text-brand-petroleo text-[34px] leading-[36px] tracking-[-0.02em]">
+                O Agenda Bela agora virou app.
+              </h1>
+              <p className="font-inter text-ink-muted text-[15px] leading-[22px]">
+                Mantenha seus dados antigos e reative cadastrando o cartão.
+                Teste grátis por 30 dias.
+              </p>
+            </div>
+
+            {/* Bullets de garantias */}
+            <ul className="space-y-2">
+              {[
+                "Você não será cobrada hoje.",
+                "Depois dos 30 dias, R$59,90/mês.",
+                "Pode cancelar quando quiser.",
+              ].map((item) => (
+                <li
+                  key={item}
+                  className="flex items-start gap-2.5 font-inter text-[14px] text-ink"
+                >
+                  <span className="inline-flex h-5 w-5 mt-0.5 items-center justify-center rounded-full bg-brand-rosa-50 text-brand-rosa font-bold text-[11px] shrink-0">
+                    ✓
+                  </span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+
+            {/* Formulário */}
+            <form onSubmit={handleLookupSubmit} className="space-y-3">
+              <div>
+                <Input
+                  type="text"
+                  placeholder="Email ou WhatsApp cadastrado"
+                  value={identifier}
+                  onChange={(e) => setIdentifier(e.target.value)}
+                  autoComplete="email"
+                  className={identifierError ? "border-red-500" : ""}
+                  aria-label="Email ou WhatsApp"
+                  aria-invalid={!!identifierError}
+                  aria-describedby={identifierError ? "identifier-error" : undefined}
+                />
+                {identifierError && (
+                  <p id="identifier-error" className="text-xs text-red-500 mt-1">
+                    {identifierError}
+                  </p>
+                )}
+              </div>
+
+              {generalError && (
+                <div
+                  role="alert"
+                  className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-md p-3"
+                >
+                  {generalError}
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                variant="brand-primary"
+                size="lg"
+                disabled={lookup.isPending}
+                className="w-full rounded-full font-inter font-semibold"
+              >
+                {lookup.isPending ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" aria-hidden />
+                    Buscando sua conta...
+                  </>
+                ) : (
+                  "Continuar"
+                )}
+              </Button>
+
+              <p className="text-center font-inter text-[12px] text-ink-muted">
+                Não tem conta?{" "}
+                <Link
+                  href="/agendabela/automatize-seu-atendimento"
+                  className="text-brand-rosa hover:text-brand-rosa-hover underline"
+                >
+                  Cadastre-se aqui
+                </Link>
+              </p>
+            </form>
+          </div>
+        )}
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Step: confirm                                                        */}
+        {/* ------------------------------------------------------------------ */}
+        {step === "confirm" && lookupResult && (
+          <div className="w-full space-y-6 pt-4">
+            <div className="space-y-2">
+              <span className="font-mono-brand text-[11px] tracking-[2px] uppercase text-brand-vinho">
+                Encontramos sua conta
+              </span>
+              <h2 className="font-fraunces italic font-normal text-brand-petroleo text-[28px] leading-[32px] tracking-[-0.015em]">
+                {lookupResult.salonName
+                  ? `${lookupResult.salonName}`
+                  : "Sua conta foi encontrada"}
+              </h2>
+            </div>
+
+            {/* Card com dados mascarados */}
+            <div className="rounded-app-md bg-brand-creme border border-brand-creme-soft p-4 space-y-2 font-inter text-[14px]">
+              {lookupResult.maskedEmail && (
+                <p>
+                  <span className="text-ink-muted">Email: </span>
+                  <span className="font-medium text-brand-petroleo">
+                    {lookupResult.maskedEmail}
+                  </span>
+                </p>
+              )}
+              {lookupResult.maskedPhone && (
+                <p>
+                  <span className="text-ink-muted">WhatsApp: </span>
+                  <span className="font-medium text-brand-petroleo">
+                    {lookupResult.maskedPhone}
+                  </span>
+                </p>
+              )}
+            </div>
+
+            <p className="font-inter text-[14px] text-ink-muted leading-relaxed">
+              Crie uma nova senha para reativar sua conta. Seus dados e
+              agendamentos anteriores serão mantidos.
+            </p>
+
+            <form onSubmit={handleConfirmSubmit} className="space-y-3">
+              {/* Senha */}
+              <div>
+                <div className="relative">
+                  <Input
+                    type={showPassword ? "text" : "password"}
+                    placeholder="Nova senha"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className={passwordError ? "border-red-500 pr-10" : "pr-10"}
+                    aria-label="Nova senha"
+                    aria-invalid={!!passwordError}
+                    aria-describedby={passwordError ? "pw-error" : "pw-hint"}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword((v) => !v)}
+                    aria-label={showPassword ? "Ocultar senha" : "Mostrar senha"}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                  >
+                    {showPassword ? (
+                      <EyeOff className="h-4 w-4" aria-hidden />
+                    ) : (
+                      <Eye className="h-4 w-4" aria-hidden />
+                    )}
+                  </button>
+                </div>
+                {passwordError ? (
+                  <p id="pw-error" className="text-xs text-red-500 mt-1">
+                    {passwordError}
+                  </p>
+                ) : (
+                  <p id="pw-hint" className="text-xs text-ink-muted mt-1">
+                    Min. 8 caracteres, maiúscula, minúscula, número e especial
+                  </p>
+                )}
+              </div>
+
+              {/* Confirmar senha */}
+              <div>
+                <div className="relative">
+                  <Input
+                    type={showConfirmPassword ? "text" : "password"}
+                    placeholder="Confirme a senha"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    className={
+                      confirmError ? "border-red-500 pr-10" : "pr-10"
+                    }
+                    aria-label="Confirme a senha"
+                    aria-invalid={!!confirmError}
+                    aria-describedby={confirmError ? "confirm-error" : undefined}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword((v) => !v)}
+                    aria-label={
+                      showConfirmPassword ? "Ocultar senha" : "Mostrar senha"
+                    }
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff className="h-4 w-4" aria-hidden />
+                    ) : (
+                      <Eye className="h-4 w-4" aria-hidden />
+                    )}
+                  </button>
+                </div>
+                {confirmError && (
+                  <p id="confirm-error" className="text-xs text-red-500 mt-1">
+                    {confirmError}
+                  </p>
+                )}
+              </div>
+
+              {generalError && (
+                <div
+                  role="alert"
+                  className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-md p-3"
+                >
+                  {generalError}
+                </div>
+              )}
+
+              {/* Garantias antes do CTA */}
+              <ul className="space-y-1.5 pt-1">
+                {[
+                  "Você não será cobrada hoje.",
+                  "Depois dos 30 dias, R$59,90/mês.",
+                  "Pode cancelar quando quiser.",
+                ].map((item) => (
+                  <li
+                    key={item}
+                    className="flex items-center gap-2 font-inter text-[13px] text-ink-muted"
+                  >
+                    <span className="text-brand-rosa font-bold text-[11px]">
+                      ✓
+                    </span>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+
+              <Button
+                type="submit"
+                variant="brand-primary"
+                size="lg"
+                disabled={startReactivation.isPending}
+                className="w-full rounded-full font-inter font-semibold"
+              >
+                {startReactivation.isPending ? (
+                  <>
+                    <Loader2
+                      className="w-4 h-4 mr-2 animate-spin"
+                      aria-hidden
+                    />
+                    Abrindo pagamento...
+                  </>
+                ) : (
+                  "Reativar com 30 dias grátis"
+                )}
+              </Button>
+
+              <button
+                type="button"
+                onClick={() => {
+                  setStep("lookup");
+                  setLookupResult(null);
+                  setPassword("");
+                  setConfirmPassword("");
+                  setGeneralError(null);
+                }}
+                className="w-full text-center font-inter text-[13px] text-ink-muted hover:text-brand-petroleo underline"
+              >
+                Não é sua conta? Voltar
+              </button>
+            </form>
+          </div>
+        )}
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Step: redirecting                                                    */}
+        {/* ------------------------------------------------------------------ */}
+        {step === "redirecting" && (
+          <div className="w-full flex flex-col items-center justify-center pt-16 gap-4 text-center">
+            <Loader2
+              className="w-10 h-10 text-brand-rosa animate-spin"
+              aria-hidden
+            />
+            <p className="font-fraunces italic text-[22px] text-brand-petroleo">
+              Abrindo pagamento...
+            </p>
+            <p className="font-inter text-[14px] text-ink-muted">
+              Você será redirecionada para o ambiente seguro da AbacatePay.
+            </p>
+          </div>
+        )}
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Step: success                                                        */}
+        {/* ------------------------------------------------------------------ */}
+        {step === "success" && (
+          <div className="w-full space-y-5 pt-4">
+            <div className="space-y-2">
+              <span className="font-mono-brand text-[11px] tracking-[2px] uppercase text-brand-vinho">
+                Tudo certo!
+              </span>
+              <h2 className="font-fraunces italic font-normal text-brand-petroleo text-[30px] leading-[34px] tracking-[-0.015em]">
+                Cartão confirmado. Bem-vinda de volta!
+              </h2>
+            </div>
+
+            <div className="rounded-app-md bg-brand-creme border border-brand-creme-soft p-4 font-inter text-[14px] text-brand-petroleo space-y-1">
+              <p className="font-semibold">30 dias grátis começam agora.</p>
+              <p className="text-ink-muted">
+                Primeira cobrança automática em 30 dias — R$59,90/mês. Cancele
+                quando quiser.
+              </p>
+            </div>
+
+            <p className="font-inter text-[14px] text-ink-muted leading-relaxed">
+              Em até 1 minuto você vai receber no WhatsApp o link para abrir o
+              app Agenda Bela. Se ainda não tiver instalado, baixe agora:
+            </p>
+
+            {/* App store badges — reutilizando componente se existir, senão links simples */}
+            <div className="flex flex-col sm:flex-row gap-3">
+              <a
+                href="https://apps.apple.com/br/app/agenda-bela/id6742810003"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 h-12 px-5 rounded-full bg-brand-petroleo text-white font-inter text-[14px] font-semibold hover:opacity-90 transition-opacity"
+              >
+                App Store (iOS)
+              </a>
+              <a
+                href="https://play.google.com/store/apps/details?id=com.tudoagenda.agendabela"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 h-12 px-5 rounded-full bg-brand-petroleo text-white font-inter text-[14px] font-semibold hover:opacity-90 transition-opacity"
+              >
+                Google Play (Android)
+              </a>
+            </div>
+          </div>
+        )}
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Step: already_active                                                 */}
+        {/* ------------------------------------------------------------------ */}
+        {step === "already_active" && (
+          <div className="w-full space-y-5 pt-4">
+            <div className="space-y-2">
+              <span className="font-mono-brand text-[11px] tracking-[2px] uppercase text-brand-vinho">
+                Conta ativa
+              </span>
+              <h2 className="font-fraunces italic font-normal text-brand-petroleo text-[28px] leading-[32px] tracking-[-0.015em]">
+                Sua conta já está ativa.
+              </h2>
+            </div>
+
+            <div
+              role="status"
+              className="rounded-app-md bg-brand-creme border border-brand-creme-soft p-4 font-inter text-[14px] text-brand-petroleo"
+            >
+              <p>
+                Você já tem uma assinatura ativa. Para acessar sua conta, use o
+                magic link que chegou no seu WhatsApp ou faça login pelo app.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <a
+                href="https://apps.apple.com/br/app/agenda-bela/id6742810003"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center h-12 px-5 rounded-full bg-brand-petroleo text-white font-inter text-[14px] font-semibold hover:opacity-90 transition-opacity"
+              >
+                Baixar app (iOS)
+              </a>
+              <a
+                href="https://play.google.com/store/apps/details?id=com.tudoagenda.agendabela"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center h-12 px-5 rounded-full bg-brand-petroleo text-white font-inter text-[14px] font-semibold hover:opacity-90 transition-opacity"
+              >
+                Baixar app (Android)
+              </a>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => setStep("lookup")}
+              className="w-full text-center font-inter text-[13px] text-ink-muted hover:text-brand-petroleo underline"
+            >
+              Tentar com outro email ou WhatsApp
+            </button>
+          </div>
+        )}
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Step: new_signup_required                                            */}
+        {/* ------------------------------------------------------------------ */}
+        {step === "new_signup_required" && (
+          <div className="w-full space-y-5 pt-4">
+            <div className="space-y-2">
+              <span className="font-mono-brand text-[11px] tracking-[2px] uppercase text-brand-vinho">
+                Conta não encontrada
+              </span>
+              <h2 className="font-fraunces italic font-normal text-brand-petroleo text-[28px] leading-[32px] tracking-[-0.015em]">
+                Não encontramos sua conta.
+              </h2>
+            </div>
+
+            <div
+              role="status"
+              className="rounded-app-md bg-brand-creme border border-brand-creme-soft p-4 font-inter text-[14px] text-brand-petroleo"
+            >
+              <p>
+                Não localizamos nenhuma conta com esse email ou WhatsApp. Se
+                você é nova por aqui, faça seu cadastro e ganhe 30 dias grátis.
+              </p>
+            </div>
+
+            <Link
+              href="/agendabela/automatize-seu-atendimento"
+              className="inline-flex items-center justify-center w-full h-12 px-6 rounded-full bg-brand-rosa hover:bg-brand-rosa-hover text-white font-inter font-semibold text-[15px] transition-colors"
+            >
+              Criar conta nova com 30 dias grátis
+            </Link>
+
+            <button
+              type="button"
+              onClick={() => {
+                setStep("lookup");
+                setIdentifier("");
+              }}
+              className="w-full text-center font-inter text-[13px] text-ink-muted hover:text-brand-petroleo underline"
+            >
+              Tentar com outro email ou WhatsApp
+            </button>
+          </div>
+        )}
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Step: token_expired                                                  */}
+        {/* ------------------------------------------------------------------ */}
+        {step === "token_expired" && (
+          <div className="w-full space-y-5 pt-4">
+            <div className="space-y-2">
+              <span className="font-mono-brand text-[11px] tracking-[2px] uppercase text-brand-vinho">
+                Sessão expirada
+              </span>
+              <h2 className="font-fraunces italic font-normal text-brand-petroleo text-[28px] leading-[32px] tracking-[-0.015em]">
+                O tempo esgotou.
+              </h2>
+            </div>
+
+            <div
+              role="alert"
+              className="rounded-app-md bg-red-50 border border-red-200 p-4 font-inter text-[14px] text-red-700"
+            >
+              <p>
+                Por segurança, a sessão expirou após 15 minutos. Por favor,
+                reinicie o processo.
+              </p>
+            </div>
+
+            <Button
+              variant="brand-primary"
+              size="lg"
+              onClick={() => {
+                setStep("lookup");
+                setLookupResult(null);
+                setPassword("");
+                setConfirmPassword("");
+                setGeneralError(null);
+              }}
+              className="w-full rounded-full font-inter font-semibold"
+            >
+              Reiniciar
+            </Button>
+          </div>
+        )}
+
+        {/* ------------------------------------------------------------------ */}
+        {/* Step: error genérico                                                 */}
+        {/* ------------------------------------------------------------------ */}
+        {step === "error" && (
+          <div className="w-full space-y-5 pt-4">
+            <div
+              role="alert"
+              className="rounded-app-md bg-red-50 border border-red-200 p-4 font-inter text-[14px] text-red-700"
+            >
+              <p className="font-semibold mb-1">Algo deu errado.</p>
+              <p>{generalError ?? "Tente novamente mais tarde."}</p>
+            </div>
+
+            <Button
+              variant="brand-primary"
+              size="lg"
+              onClick={() => {
+                setStep("lookup");
+                setGeneralError(null);
+              }}
+              className="w-full rounded-full font-inter font-semibold"
+            >
+              Tentar novamente
+            </Button>
+          </div>
+        )}
+      </main>
+
+      {/* Footer mínimo */}
+      <footer className="px-5 py-6 border-t border-surface-alt-border">
+        <nav className="flex flex-wrap justify-center gap-4">
+          <Link
+            href="/termos"
+            className="font-inter text-[12px] text-ink-muted hover:text-brand-petroleo transition-colors"
+          >
+            Termos de serviço
+          </Link>
+          <Link
+            href="/privacidade"
+            className="font-inter text-[12px] text-ink-muted hover:text-brand-petroleo transition-colors"
+          >
+            Política de privacidade
+          </Link>
+          <a
+            href="mailto:contato@tudoagenda.com.br"
+            className="font-inter text-[12px] text-ink-muted hover:text-brand-petroleo transition-colors"
+          >
+            contato@tudoagenda.com.br
+          </a>
+        </nav>
+        <p className="text-center font-inter text-[11px] text-ink-subtle mt-4">
+          © {new Date().getFullYear()} Tudo Agenda. Todos os direitos
+          reservados.
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/api/agendabela/reactivation/lookup/__tests__/route.test.ts
+++ b/src/app/api/agendabela/reactivation/lookup/__tests__/route.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @jest-environment node
+ *
+ * Testes do BFF de lookup de reativação.
+ * Cobre: validação de input, repasse ao backend, normalização de erros.
+ */
+
+import { POST } from "../route";
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  process.env = {
+    ...originalEnv,
+    BACKEND_API_URL: "https://api.example.test/api",
+    INTERNAL_API_KEY: "test-internal-key",
+  };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/agendabela/reactivation/lookup", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/agendabela/reactivation/lookup", () => {
+  test("rejects empty identifier", async () => {
+    const response = await POST(makeRequest({ identifier: "" }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  test("rejects missing identifier", async () => {
+    const response = await POST(makeRequest({}));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  test("rejects identifier that is neither email nor phone", async () => {
+    const response = await POST(makeRequest({ identifier: "abc" }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  test("accepts valid email and forwards lowercase to backend", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          status: "LEGACY_INACTIVE",
+          salonName: "Salão da Loide",
+          maskedEmail: "l***@hotmail.com",
+          maskedPhone: "(11) 9****-3421",
+          lookupToken: "tok_abc123",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const response = await POST(makeRequest({ identifier: "Loide@hotmail.com" }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/api/subscriptions/reactivation/lookup",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ identifier: "loide@hotmail.com" }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("LEGACY_INACTIVE");
+    expect(body.salonName).toBe("Salão da Loide");
+  });
+
+  test("accepts valid phone number (digits only) and strips formatting", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ status: "LEGACY_INACTIVE", lookupToken: "tok_xyz" }),
+        { status: 200 },
+      ),
+    );
+
+    const response = await POST(makeRequest({ identifier: "(11) 99999-1234" }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({ identifier: "11999991234" }),
+      }),
+    );
+    expect(response.status).toBe(200);
+  });
+
+  test("includes X-Internal-Key header when env var is set", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: "ALREADY_ACTIVE" }), { status: 200 }),
+    );
+
+    await POST(makeRequest({ identifier: "test@example.com" }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "X-Internal-Key": "test-internal-key",
+        }),
+      }),
+    );
+  });
+
+  test("proxies backend 4xx with passthrough status", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ message: "Profile not found", code: "NOT_FOUND" }),
+        { status: 404 },
+      ),
+    );
+
+    const response = await POST(makeRequest({ identifier: "unknown@test.com" }));
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  test("returns 502 when backend returns 5xx", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response("Internal server error", { status: 500 }),
+    );
+
+    const response = await POST(makeRequest({ identifier: "test@example.com" }));
+    expect(response.status).toBe(502);
+  });
+
+  test("returns 500 on unexpected exception", async () => {
+    jest.spyOn(global, "fetch").mockRejectedValueOnce(new Error("Network error"));
+
+    const response = await POST(makeRequest({ identifier: "test@example.com" }));
+    expect(response.status).toBe(500);
+  });
+
+  test("handles ALREADY_ACTIVE status transparently", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: "ALREADY_ACTIVE" }), { status: 200 }),
+    );
+
+    const response = await POST(makeRequest({ identifier: "ativa@example.com" }));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("ALREADY_ACTIVE");
+  });
+
+  test("handles NEW_SIGNUP_REQUIRED status transparently", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: "NEW_SIGNUP_REQUIRED" }), { status: 200 }),
+    );
+
+    const response = await POST(makeRequest({ identifier: "nova@example.com" }));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("NEW_SIGNUP_REQUIRED");
+  });
+});

--- a/src/app/api/agendabela/reactivation/lookup/route.ts
+++ b/src/app/api/agendabela/reactivation/lookup/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// WhatsApp: aceita com ou sem código de país, apenas dígitos
+const PHONE_DIGITS_MIN = 10;
+
+function getBackendApiUrl(): string {
+  return (
+    process.env.BACKEND_API_URL ||
+    "https://api.agendabela.tudoagenda.com.br/api"
+  );
+}
+
+function buildInternalHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (process.env.INTERNAL_API_KEY) {
+    headers["X-Internal-Key"] = process.env.INTERNAL_API_KEY;
+  }
+  return headers;
+}
+
+/**
+ * BFF: repassa POST /subscriptions/reactivation/lookup ao backend.
+ * Valida o identificador (email ou telefone) antes de chamar o backend.
+ */
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const raw: string =
+      typeof body?.identifier === "string" ? body.identifier.trim() : "";
+
+    if (!raw) {
+      return NextResponse.json(
+        { error: "Email ou WhatsApp é obrigatório." },
+        { status: 400 },
+      );
+    }
+
+    const isEmail = EMAIL_REGEX.test(raw);
+    const phoneDigits = raw.replace(/\D/g, "");
+    const isPhone = !isEmail && phoneDigits.length >= PHONE_DIGITS_MIN;
+
+    if (!isEmail && !isPhone) {
+      return NextResponse.json(
+        { error: "Informe um email ou número de WhatsApp válido." },
+        { status: 400 },
+      );
+    }
+
+    const backendRes = await fetch(
+      `${getBackendApiUrl()}/subscriptions/reactivation/lookup`,
+      {
+        method: "POST",
+        headers: buildInternalHeaders(),
+        body: JSON.stringify({
+          identifier: isEmail ? raw.toLowerCase() : phoneDigits,
+        }),
+      },
+    );
+
+    const responseBody = await backendRes.json().catch(() => ({}));
+
+    if (!backendRes.ok) {
+      console.error(
+        "[Reactivation/lookup] Backend error:",
+        backendRes.status,
+        responseBody,
+      );
+      return NextResponse.json(
+        {
+          error:
+            responseBody?.message ??
+            "Erro ao buscar conta. Tente novamente.",
+          code: responseBody?.code,
+        },
+        { status: backendRes.status >= 500 ? 502 : backendRes.status },
+      );
+    }
+
+    return NextResponse.json(responseBody);
+  } catch (err) {
+    console.error("[Reactivation/lookup] Unexpected error:", err);
+    return NextResponse.json(
+      { error: "Erro interno. Tente novamente." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/agendabela/reactivation/start/__tests__/route.test.ts
+++ b/src/app/api/agendabela/reactivation/start/__tests__/route.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @jest-environment node
+ *
+ * Testes do BFF de start de reativação.
+ * Cobre: validação de lookupToken e password, repasse ao backend,
+ * tratamento de token expirado (410), checkout indisponível.
+ */
+
+import { POST } from "../route";
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  process.env = {
+    ...originalEnv,
+    BACKEND_API_URL: "https://api.example.test/api",
+    INTERNAL_API_KEY: "test-internal-key",
+  };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/agendabela/reactivation/start", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/agendabela/reactivation/start", () => {
+  const validBody = {
+    lookupToken: "tok_valid_abc123",
+    newPassword: "MinhaSenh4!",
+  };
+
+  test("rejects missing lookupToken", async () => {
+    const response = await POST(makeRequest({ newPassword: "MinhaSenh4!" }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  test("rejects empty lookupToken", async () => {
+    const response = await POST(makeRequest({ lookupToken: "", newPassword: "MinhaSenh4!" }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  test("rejects short password (< 8 chars)", async () => {
+    const response = await POST(makeRequest({ lookupToken: "tok_abc", newPassword: "abc" }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  test("forwards valid payload to backend and returns checkoutUrl", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ checkoutUrl: "https://pay.abacatepay.com/checkout/mock123" }),
+        { status: 200 },
+      ),
+    );
+
+    const response = await POST(makeRequest(validBody));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/api/subscriptions/reactivation/start",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(validBody),
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "X-Internal-Key": "test-internal-key",
+        }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.checkoutUrl).toBe("https://pay.abacatepay.com/checkout/mock123");
+  });
+
+  test("returns 410 with TOKEN_EXPIRED code when backend returns 410", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ message: "Token expired" }),
+        { status: 410 },
+      ),
+    );
+
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(410);
+    const body = await response.json();
+    expect(body.code).toBe("TOKEN_EXPIRED");
+    expect(body.error).toBeTruthy();
+  });
+
+  test("returns 502 when backend is missing checkoutUrl in 200 response", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true }), { status: 200 }),
+    );
+
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  test("returns 502 when backend returns 5xx", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response("Gateway error", { status: 503 }),
+    );
+
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(502);
+  });
+
+  test("returns 500 on unexpected exception", async () => {
+    jest.spyOn(global, "fetch").mockRejectedValueOnce(new Error("Connection refused"));
+
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(500);
+  });
+
+  test("proxies backend 4xx errors (non-410) with original status", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ message: "Invalid token", code: "INVALID_TOKEN" }),
+        { status: 422 },
+      ),
+    );
+
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error).toBeTruthy();
+  });
+});

--- a/src/app/api/agendabela/reactivation/start/route.ts
+++ b/src/app/api/agendabela/reactivation/start/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server";
+
+function getBackendApiUrl(): string {
+  return (
+    process.env.BACKEND_API_URL ||
+    "https://api.agendabela.tudoagenda.com.br/api"
+  );
+}
+
+function buildInternalHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (process.env.INTERNAL_API_KEY) {
+    headers["X-Internal-Key"] = process.env.INTERNAL_API_KEY;
+  }
+  return headers;
+}
+
+/**
+ * BFF: repassa POST /subscriptions/reactivation/start ao backend.
+ * Recebe lookupToken + newPassword; retorna checkoutUrl.
+ */
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const lookupToken: string =
+      typeof body?.lookupToken === "string" ? body.lookupToken.trim() : "";
+    const newPassword: string =
+      typeof body?.newPassword === "string" ? body.newPassword : "";
+
+    if (!lookupToken) {
+      return NextResponse.json(
+        { error: "Token de lookup ausente. Recomece o fluxo." },
+        { status: 400 },
+      );
+    }
+
+    if (!newPassword || newPassword.length < 8) {
+      return NextResponse.json(
+        { error: "Senha deve ter no mínimo 8 caracteres." },
+        { status: 400 },
+      );
+    }
+
+    const backendRes = await fetch(
+      `${getBackendApiUrl()}/subscriptions/reactivation/start`,
+      {
+        method: "POST",
+        headers: buildInternalHeaders(),
+        body: JSON.stringify({ lookupToken, newPassword }),
+      },
+    );
+
+    const responseBody = await backendRes.json().catch(() => ({}));
+
+    if (!backendRes.ok) {
+      console.error(
+        "[Reactivation/start] Backend error:",
+        backendRes.status,
+        responseBody,
+      );
+
+      // 410 = token expirado
+      if (backendRes.status === 410) {
+        return NextResponse.json(
+          {
+            error:
+              "Sessão expirada. Por favor, reinicie o processo de reativação.",
+            code: "TOKEN_EXPIRED",
+          },
+          { status: 410 },
+        );
+      }
+
+      return NextResponse.json(
+        {
+          error:
+            responseBody?.message ??
+            "Erro ao iniciar reativação. Tente novamente.",
+          code: responseBody?.code,
+        },
+        { status: backendRes.status >= 500 ? 502 : backendRes.status },
+      );
+    }
+
+    const checkoutUrl = responseBody?.checkoutUrl;
+
+    if (!checkoutUrl) {
+      console.error(
+        "[Reactivation/start] Backend missing checkoutUrl:",
+        responseBody,
+      );
+      return NextResponse.json(
+        { error: "Resposta inválida do serviço de pagamento." },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({ checkoutUrl });
+  } catch (err) {
+    console.error("[Reactivation/start] Unexpected error:", err);
+    return NextResponse.json(
+      { error: "Erro interno. Tente novamente." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/hooks/use-reactivation.ts
+++ b/src/hooks/use-reactivation.ts
@@ -1,0 +1,28 @@
+import { useMutation } from "@tanstack/react-query";
+import {
+  reactivationService,
+  ReactivationLookupResponse,
+  ReactivationStartPayload,
+  ReactivationStartResponse,
+  ReactivationApiError,
+} from "@/services/reactivation";
+
+export type { ReactivationLookupResponse, ReactivationApiError };
+
+export function useReactivationLookup() {
+  return useMutation<ReactivationLookupResponse, ReactivationApiError, string>({
+    mutationFn: (identifier: string) =>
+      reactivationService.lookup(identifier) as Promise<ReactivationLookupResponse>,
+  });
+}
+
+export function useReactivationStart() {
+  return useMutation<
+    ReactivationStartResponse,
+    ReactivationApiError,
+    ReactivationStartPayload
+  >({
+    mutationFn: (payload) =>
+      reactivationService.start(payload) as Promise<ReactivationStartResponse>,
+  });
+}

--- a/src/lib/analytics/dataLayer.ts
+++ b/src/lib/analytics/dataLayer.ts
@@ -31,6 +31,17 @@ type LandingEvent =
     }
   | {
       event: "lp_signup_completed";
+    }
+  | {
+      event: "paywall_viewed";
+      flow: "reactivation" | "manage";
+      alert_kind?: string;
+      landing_slug: string;
+    }
+  | {
+      event: "checkout_opened";
+      flow: "reactivation" | "new_signup";
+      source: string;
     };
 
 type LandingContext = {
@@ -49,6 +60,18 @@ export function pushAgendaBelaMainEvent(eventData: LandingEvent): void {
     product: "agendabela",
     landing_type: "main",
     landing_slug: "automatize-seu-atendimento",
+  });
+}
+
+/**
+ * Faz push de um evento da LP de reativação do Agenda Bela.
+ * Contexto: campaign, slug = reativacao.
+ */
+export function pushAgendaBelaReativacaoEvent(eventData: LandingEvent): void {
+  pushLandingEvent(eventData, {
+    product: "agendabela",
+    landing_type: "campaign",
+    landing_slug: "reativacao",
   });
 }
 

--- a/src/services/reactivation.ts
+++ b/src/services/reactivation.ts
@@ -1,0 +1,151 @@
+/**
+ * Client tipado para os endpoints de reativação (backend #86).
+ *
+ * Endpoints:
+ *   POST /subscriptions/reactivation/lookup
+ *   POST /subscriptions/reactivation/start
+ *
+ * O switch entre real e mock é controlado por NEXT_PUBLIC_USE_REACTIVATION_MOCK.
+ * Em produção a landing aponta para /api/agendabela/reactivation/lookup e
+ * /api/agendabela/reactivation/start (Next.js BFF que repassa ao backend).
+ */
+
+// ---------------------------------------------------------------------------
+// Tipos do contrato de backend #86
+// ---------------------------------------------------------------------------
+
+export type ReactivationLookupStatus =
+  | "LEGACY_INACTIVE"   // Profile existente, inativo, sem gateway — fluxo desta LP
+  | "ALREADY_ACTIVE"    // Profile ACTIVE/TRIALING moderno — orientar login
+  | "NEW_SIGNUP_REQUIRED"; // Nenhum profile encontrado — encaminhar para cadastro novo
+
+export interface ReactivationLookupResponse {
+  status: ReactivationLookupStatus;
+  /** Presente quando status = LEGACY_INACTIVE */
+  salonName?: string;
+  /** Email mascarado: j***@example.com */
+  maskedEmail?: string;
+  /** WhatsApp mascarado: (11) 9****-1234 */
+  maskedPhone?: string;
+  /** Token opaco pra correlacionar lookup → start (TTL: 15 min) */
+  lookupToken?: string;
+}
+
+export interface ReactivationStartPayload {
+  lookupToken: string;
+  newPassword: string;
+}
+
+export interface ReactivationStartResponse {
+  checkoutUrl: string;
+}
+
+// ---------------------------------------------------------------------------
+// Erros tipados
+// ---------------------------------------------------------------------------
+
+export class ReactivationApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = "ReactivationApiError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock (desenvolvimento local sem backend)
+// ---------------------------------------------------------------------------
+
+async function mockLookup(
+  identifier: string,
+): Promise<ReactivationLookupResponse> {
+  await new Promise((r) => setTimeout(r, 800));
+
+  if (identifier.includes("ativo")) {
+    return { status: "ALREADY_ACTIVE" };
+  }
+  if (identifier.includes("novo")) {
+    return { status: "NEW_SIGNUP_REQUIRED" };
+  }
+  // Padrão: base legado inativa
+  return {
+    status: "LEGACY_INACTIVE",
+    salonName: "Salão da Loide",
+    maskedEmail: "l***@hotmail.com",
+    maskedPhone: "(11) 9****-3421",
+    lookupToken: "mock-token-abc123",
+  };
+}
+
+async function mockStart(): Promise<ReactivationStartResponse> {
+  await new Promise((r) => setTimeout(r, 1000));
+  return { checkoutUrl: "https://pay.abacatepay.com/mock-checkout" };
+}
+
+// ---------------------------------------------------------------------------
+// Implementação real (via BFF Next.js → backend)
+// ---------------------------------------------------------------------------
+
+async function realLookup(
+  identifier: string,
+): Promise<ReactivationLookupResponse> {
+  const res = await fetch("/api/agendabela/reactivation/lookup", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ identifier: identifier.trim().toLowerCase() }),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new ReactivationApiError(
+      body?.error ?? "Erro ao buscar conta. Tente novamente.",
+      res.status,
+      body?.code,
+    );
+  }
+
+  return res.json();
+}
+
+async function realStart(
+  payload: ReactivationStartPayload,
+): Promise<ReactivationStartResponse> {
+  const res = await fetch("/api/agendabela/reactivation/start", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new ReactivationApiError(
+      body?.error ?? "Erro ao iniciar reativação. Tente novamente.",
+      res.status,
+      body?.code,
+    );
+  }
+
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Facade exportada — troca entre mock e real via env
+// ---------------------------------------------------------------------------
+
+function isMockEnabled(): boolean {
+  return (
+    process.env.NEXT_PUBLIC_USE_REACTIVATION_MOCK === "true" ||
+    process.env.NODE_ENV === "development"
+  );
+}
+
+export const reactivationService = {
+  lookup: (identifier: string): Promise<ReactivationLookupResponse> =>
+    isMockEnabled() ? mockLookup(identifier) : realLookup(identifier),
+
+  start: (payload: ReactivationStartPayload): Promise<ReactivationStartResponse> =>
+    isMockEnabled() ? mockStart() : realStart(payload),
+};


### PR DESCRIPTION
## Contexto

Epic #21 — Reativação card-first da base legado Agenda Bela (tudoagenda-companion-os).

Massa em prod (2026-05-29): 2.355 Cognito, 1.526 profiles, 1.519 INACTIVE sem assinatura moderna.

Closes #60

## O que este PR faz

- Página `/agendabela/reativar` com fluxo step-by-step de reativação para base legada
- BFF Next.js em `/api/agendabela/reactivation/lookup` e `/api/agendabela/reactivation/start` que repassam ao backend (issue #86)
- Client tipado (`services/reactivation.ts`) com switch mock/real via `NEXT_PUBLIC_USE_REACTIVATION_MOCK`
- Hooks React Query (`hooks/use-reactivation.ts`)
- Metadata SEO com `robots: { index: false }` (LP de campanha)
- 20 testes nos BFF routes (lookup + start): validação de input, repasse ao backend, normalização de 410/5xx, token expirado, checkout indisponível

## Fluxo implementado

1. Usuária informa email ou WhatsApp
2. LP chama lookup → mostra dados mascarados (nome salão, email mascarado, WhatsApp final)
3. `paywall_viewed` disparado via dataLayer (GTM)
4. Usuária cria nova senha → CTA chama start → recebe `checkoutUrl` → redireciona AbacatePay
5. `checkout_opened` (flow: reactivation, source: lp_reactivation) antes do redirect
6. Volta com `?reactivation=success` → tela de sucesso com links app stores

## Estados tratados

- `LEGACY_INACTIVE` → fluxo principal (confirmação + senha + checkout)
- `ALREADY_ACTIVE` → orienta login/magic link
- `NEW_SIGNUP_REQUIRED` → encaminha cadastro novo
- `TOKEN_EXPIRED` (410) → instrui reiniciar
- Backend indisponível → erro genérico com retry

## Copy obrigatória (todas presentes)

- "O Agenda Bela agora virou app."
- "Mantenha seus dados antigos."
- "Você não será cobrada hoje."
- "Depois dos 30 dias, R$59,90/mês."
- "Pode cancelar quando quiser."

## Gap de backend

O endpoint `POST /subscriptions/reactivation/lookup` e `POST /subscriptions/reactivation/start` (issue #86) podem não estar em dev ainda. O client usa mock automático em `NODE_ENV=development`. Em prod, `NEXT_PUBLIC_USE_REACTIVATION_MOCK=false` ativa o path real.

## Plano de teste

- [ ] `npm test` → 20 testes passando (BFF routes)
- [ ] `npm run lint` → zero erros
- [ ] `npm run build` → build limpo
- [ ] **Manual mock**: abrir `/agendabela/reativar`, inserir qualquer email → ver step "confirm" com dados do Salão da Loide
- [ ] **Manual mock**: inserir "ativo" no campo → ver tela `already_active`
- [ ] **Manual mock**: inserir "novo" no campo → ver tela `new_signup_required`
- [ ] Criar senha válida no step confirm → ver tela "redirecting" → redirect para mock AbacatePay
- [ ] Voltar com `?reactivation=success` → ver tela success com links app stores
- [ ] Verificar que `paywall_viewed` e `checkout_opened` aparecem no `window.dataLayer` (DevTools)

## Referências

- Epic: tudoagenda/tudoagenda-companion-os#21
- Design canônico: `produtos/agenda-bela/designs/2026-05-29-card-first-signup-e-reativacao.md`
- ADR 0009 (card-first): `empresa/decisoes/0009-card-first-signup-activation.md`
- PR relacionado web: tudoagenda/agendabela-web#107 (em aberto)
- PR relacionado CRM: tudoagenda/tudoagenda-crm-web#8 (em aberto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)