### PR TITLE
fix(reactivation): alinha contrato da LP com backend #86

### DIFF
--- a/src/app/agendabela/reativar/reactivation-flow.tsx
+++ b/src/app/agendabela/reativar/reactivation-flow.tsx
@@ -99,7 +99,7 @@ export function ReactivationFlow() {
           return;
         }
 
-        // LEGACY_INACTIVE — mostra confirmação + dispara paywall_viewed
+        // LEGACY_PROFILE_FOUND — mostra confirmação + dispara paywall_viewed
         setStep("confirm");
         pushAgendaBelaReativacaoEvent({
           event: "paywall_viewed",
@@ -130,7 +130,7 @@ export function ReactivationFlow() {
       return;
     }
 
-    if (!lookupResult?.lookupToken) {
+    if (!lookupResult?.reactivationToken) {
       setGeneralError("Sessão perdida. Reinicie o processo.");
       setStep("lookup");
       return;
@@ -144,7 +144,7 @@ export function ReactivationFlow() {
     });
 
     startReactivation.mutate(
-      { lookupToken: lookupResult.lookupToken, newPassword: password },
+      { reactivationToken: lookupResult.reactivationToken, password },
       {
         onSuccess: (data) => {
           setStep("redirecting");

--- a/src/app/api/agendabela/reactivation/start/__tests__/route.test.ts
+++ b/src/app/api/agendabela/reactivation/start/__tests__/route.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  *
  * Testes do BFF de start de reativação.
- * Cobre: validação de lookupToken e password, repasse ao backend,
+ * Cobre: validação de reactivationToken e password, repasse ao backend,
  * tratamento de token expirado (410), checkout indisponível.
  */
 
@@ -33,26 +33,26 @@ function makeRequest(body: Record<string, unknown>) {
 
 describe("POST /api/agendabela/reactivation/start", () => {
   const validBody = {
-    lookupToken: "tok_valid_abc123",
-    newPassword: "MinhaSenh4!",
+    reactivationToken: "tok_valid_abc123",
+    password: "MinhaSenh4!",
   };
 
-  test("rejects missing lookupToken", async () => {
-    const response = await POST(makeRequest({ newPassword: "MinhaSenh4!" }));
+  test("rejects missing reactivationToken", async () => {
+    const response = await POST(makeRequest({ password: "MinhaSenh4!" }));
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toBeTruthy();
   });
 
-  test("rejects empty lookupToken", async () => {
-    const response = await POST(makeRequest({ lookupToken: "", newPassword: "MinhaSenh4!" }));
+  test("rejects empty reactivationToken", async () => {
+    const response = await POST(makeRequest({ reactivationToken: "", password: "MinhaSenh4!" }));
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toBeTruthy();
   });
 
   test("rejects short password (< 8 chars)", async () => {
-    const response = await POST(makeRequest({ lookupToken: "tok_abc", newPassword: "abc" }));
+    const response = await POST(makeRequest({ reactivationToken: "tok_abc", password: "abc" }));
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toBeTruthy();

--- a/src/app/api/agendabela/reactivation/start/route.ts
+++ b/src/app/api/agendabela/reactivation/start/route.ts
@@ -17,24 +17,27 @@ function buildInternalHeaders(): Record<string, string> {
 
 /**
  * BFF: repassa POST /subscriptions/reactivation/start ao backend.
- * Recebe lookupToken + newPassword; retorna checkoutUrl.
+ * Recebe reactivationToken + password (contrato canônico do backend #86,
+ * documentado em `src/subscriptions/dto/reactivation-start.dto.ts`).
  */
 export async function POST(req: Request) {
   try {
     const body = await req.json();
-    const lookupToken: string =
-      typeof body?.lookupToken === "string" ? body.lookupToken.trim() : "";
-    const newPassword: string =
-      typeof body?.newPassword === "string" ? body.newPassword : "";
+    const reactivationToken: string =
+      typeof body?.reactivationToken === "string"
+        ? body.reactivationToken.trim()
+        : "";
+    const password: string =
+      typeof body?.password === "string" ? body.password : "";
 
-    if (!lookupToken) {
+    if (!reactivationToken) {
       return NextResponse.json(
-        { error: "Token de lookup ausente. Recomece o fluxo." },
+        { error: "Token de reativação ausente. Recomece o fluxo." },
         { status: 400 },
       );
     }
 
-    if (!newPassword || newPassword.length < 8) {
+    if (!password || password.length < 8) {
       return NextResponse.json(
         { error: "Senha deve ter no mínimo 8 caracteres." },
         { status: 400 },
@@ -46,7 +49,7 @@ export async function POST(req: Request) {
       {
         method: "POST",
         headers: buildInternalHeaders(),
-        body: JSON.stringify({ lookupToken, newPassword }),
+        body: JSON.stringify({ reactivationToken, password }),
       },
     );
 

--- a/src/services/reactivation.ts
+++ b/src/services/reactivation.ts
@@ -15,25 +15,25 @@
 // ---------------------------------------------------------------------------
 
 export type ReactivationLookupStatus =
-  | "LEGACY_INACTIVE"   // Profile existente, inativo, sem gateway — fluxo desta LP
-  | "ALREADY_ACTIVE"    // Profile ACTIVE/TRIALING moderno — orientar login
-  | "NEW_SIGNUP_REQUIRED"; // Nenhum profile encontrado — encaminhar para cadastro novo
+  | "LEGACY_PROFILE_FOUND"  // Profile existente, inativo, sem gateway — fluxo desta LP
+  | "ALREADY_ACTIVE"        // Profile ACTIVE/TRIALING moderno — orientar login
+  | "NEW_SIGNUP_REQUIRED";  // Nenhum profile encontrado — encaminhar para cadastro novo
 
 export interface ReactivationLookupResponse {
   status: ReactivationLookupStatus;
-  /** Presente quando status = LEGACY_INACTIVE */
+  /** Presente quando status = LEGACY_PROFILE_FOUND */
   salonName?: string;
   /** Email mascarado: j***@example.com */
   maskedEmail?: string;
   /** WhatsApp mascarado: (11) 9****-1234 */
   maskedPhone?: string;
-  /** Token opaco pra correlacionar lookup → start (TTL: 15 min) */
-  lookupToken?: string;
+  /** JWT HS256, TTL 15min, payload `{ profileId, purpose: 'reactivation' }`. Presente em LEGACY_PROFILE_FOUND. */
+  reactivationToken?: string;
 }
 
 export interface ReactivationStartPayload {
-  lookupToken: string;
-  newPassword: string;
+  reactivationToken: string;
+  password: string;
 }
 
 export interface ReactivationStartResponse {
@@ -72,11 +72,11 @@ async function mockLookup(
   }
   // Padrão: base legado inativa
   return {
-    status: "LEGACY_INACTIVE",
+    status: "LEGACY_PROFILE_FOUND",
     salonName: "Salão da Loide",
     maskedEmail: "l***@hotmail.com",
     maskedPhone: "(11) 9****-3421",
-    lookupToken: "mock-token-abc123",
+    reactivationToken: "mock-token-abc123",
   };
 }
 


### PR DESCRIPTION
## Contexto

Bug bloqueante detectado em produção durante QA real da reativação.

A LP `/agendabela/reativar` (PR [#61](https://github.com/tudoagenda/tudoagenda-landing-pages/pull/61), epic [tudoagenda/tudoagenda-companion-os#21](https://github.com/tudoagenda/tudoagenda-companion-os/issues/21)) usava nomes divergentes do contrato canônico publicado pelo backend (PR [agendabela-backend-services#89](https://github.com/tudoagenda/agendabela-backend-services/pull/89)):

| Campo | Backend (canônico) | LP (errado) |
|---|---|---|
| Status do lookup | \`LEGACY_PROFILE_FOUND\` | \`LEGACY_INACTIVE\` |
| Token no lookup | \`reactivationToken\` | \`lookupToken\` |
| Payload do start | \`{ reactivationToken, password }\` | \`{ lookupToken, newPassword }\` |

## Sintoma observado em prod

Usuária preenche email → vai pra tela de senha → clica "Reativar com 30 dias grátis" → **nada acontece visualmente**, volta pra tela inicial. O fluxo end-to-end é bloqueado.

Causa: \`lookupResult?.lookupToken\` resulta \`undefined\` porque o backend retorna \`reactivationToken\`. O guard \`if (!lookupResult?.lookupToken)\` dispara \`"Sessão perdida"\` + \`setStep("lookup")\`, jogando o usuário pra tela inicial sem feedback claro.

## Mudanças

- \`services/reactivation.ts\`: tipo \`ReactivationLookupStatus\` agora usa \`LEGACY_PROFILE_FOUND\`. Campos \`lookupToken → reactivationToken\` e \`newPassword → password\` no payload de start.
- \`app/agendabela/reativar/reactivation-flow.tsx\`: lê \`reactivationToken\` e envia payload com nome correto.
- \`app/api/agendabela/reactivation/start/route.ts\`: BFF passa direto os mesmos nomes do contrato (sem remap), respeitando \`src/subscriptions/dto/reactivation-start.dto.ts\` do backend.
- Testes do BFF (\`start/__tests__/route.test.ts\`) atualizados — 20 testes passando.

## Test plan

- [ ] Lookup de email legado retorna \`status: LEGACY_PROFILE_FOUND\` + \`reactivationToken\` → mostra tela de confirmação.
- [ ] Submeter senha com token válido → backend cria checkout → redireciona pra AbacatePay.
- [ ] Token expirado (>15min) → mostra tela \`token_expired\`.
- [ ] Fluxo end-to-end via Loide funciona.

## Refs

- Epic: tudoagenda/tudoagenda-companion-os#21
- LP original: #61
- Backend canônico: tudoagenda/agendabela-backend-services#89 (\`reactivation-start.dto.ts\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)