### PR TITLE
feat(lista-de-espera): LP de pré-lançamento com captura no Google Sheets

### DIFF
--- a/docs/lista-de-espera-apps-script.md
+++ b/docs/lista-de-espera-apps-script.md
@@ -1,0 +1,101 @@
+# Lista de espera — integração com Google Sheets
+
+A LP `/agendabela/lista-de-espera` salva os cadastros (nome + WhatsApp) numa
+planilha do Google via um **Google Apps Script Web App**.
+
+Fluxo:
+
+```
+Form (LP) → POST /api/agendabela/waitlist (BFF) → Apps Script /exec → append na planilha
+```
+
+O BFF (`src/app/api/agendabela/waitlist/route.ts`) valida/normaliza e repassa.
+O Apps Script faz o `appendRow` na planilha. Nenhuma credencial do Google
+fica no app — só a URL `/exec` (e um segredo opcional).
+
+## 1. Abrir o editor de script da planilha
+
+1. Abra a planilha (conta `tudoagendaagendabela@gmail.com`):
+   <https://docs.google.com/spreadsheets/d/1IDXcBydDqkpPuZZ61GYBWYzmxUpHS0dwxMdtIhezSyc/edit>
+2. Menu **Extensões → Apps Script**.
+3. Apague o conteúdo padrão e cole o código abaixo.
+
+## 2. Código do Apps Script
+
+```javascript
+// Segredo compartilhado: precisa ser IGUAL ao AGENDABELA_WAITLIST_SECRET do app.
+// Deixe "" se não for usar segredo (não recomendado em produção).
+const SECRET = "TROQUE_POR_UM_SEGREDO_FORTE";
+
+function doPost(e) {
+  try {
+    const body = JSON.parse(e.postData.contents || "{}");
+
+    if (SECRET && body.secret !== SECRET) {
+      return json({ error: "unauthorized" });
+    }
+
+    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheets()[0];
+
+    // Cria cabeçalho na primeira execução, se a planilha estiver vazia.
+    if (sheet.getLastRow() === 0) {
+      sheet.appendRow(["Data", "Nome", "WhatsApp", "Origem"]);
+    }
+
+    sheet.appendRow([
+      new Date(),
+      String(body.name || ""),
+      String(body.whatsapp || ""),
+      String(body.source || ""),
+    ]);
+
+    return json({ ok: true });
+  } catch (err) {
+    return json({ error: String(err) });
+  }
+}
+
+function json(obj) {
+  return ContentService.createTextOutput(JSON.stringify(obj)).setMimeType(
+    ContentService.MimeType.JSON
+  );
+}
+```
+
+> Obs: o Apps Script Web App não define status HTTP custom em respostas de
+> `ContentService` (sempre 200). Por isso o script retorna `{ ok: true }` no
+> sucesso e `{ error: ... }` no erro, e o **BFF valida o corpo** (`ok === true`),
+> não só o status. O `status` passado pra `json()` é ignorado pelo Apps Script
+> e fica só como documentação.
+
+## 3. Publicar como Web App
+
+1. No editor: **Implantar → Nova implantação**.
+2. Tipo: **App da Web**.
+3. **Executar como:** Eu (`tudoagendaagendabela@gmail.com`).
+4. **Quem pode acessar:** **Qualquer pessoa** (necessário pro BFF chamar sem login).
+5. **Implantar** → autorize as permissões da conta.
+6. Copie a **URL do app da Web** (termina em `/exec`).
+
+A cada mudança no código, use **Implantar → Gerenciar implantações → editar →
+Nova versão** pra que a URL `/exec` reflita o código novo.
+
+## 4. Configurar as env vars do app (Railway)
+
+No serviço da `tudoagenda-landing-pages`:
+
+| Variável | Valor |
+| --- | --- |
+| `AGENDABELA_WAITLIST_WEBHOOK_URL` | a URL `/exec` copiada no passo 3 |
+| `AGENDABELA_WAITLIST_SECRET` | o mesmo valor de `SECRET` no script |
+
+Local (não commitar): coloque as duas num `.env.local`.
+
+## 5. Testar
+
+```bash
+curl -X POST http://localhost:3000/api/agendabela/waitlist \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Teste","whatsapp":"(11) 91234-5678"}'
+# esperado: {"ok":true} e uma linha nova na planilha
+```

--- a/docs/lista-de-espera-apps-script.md
+++ b/docs/lista-de-espera-apps-script.md
@@ -27,6 +27,11 @@ fica no app — só a URL `/exec` (e um segredo opcional).
 // Deixe "" se não for usar segredo (não recomendado em produção).
 const SECRET = "TROQUE_POR_UM_SEGREDO_FORTE";
 
+// ID da planilha (o trecho entre /d/ e /edit na URL). Usamos openById em vez de
+// getActiveSpreadsheet() porque num Web App publicado (execução via HTTP) não
+// existe planilha "ativa" no contexto — getActiveSpreadsheet() retorna null.
+const SHEET_ID = "1IDXcBydDqkpPuZZ61GYBWYzmxUpHS0dwxMdtIhezSyc";
+
 function doPost(e) {
   try {
     const body = JSON.parse(e.postData.contents || "{}");
@@ -35,7 +40,7 @@ function doPost(e) {
       return json({ error: "unauthorized" });
     }
 
-    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheets()[0];
+    const sheet = SpreadsheetApp.openById(SHEET_ID).getSheets()[0];
 
     // Cria cabeçalho na primeira execução, se a planilha estiver vazia.
     if (sheet.getLastRow() === 0) {

--- a/src/app/agendabela/lista-de-espera/layout.tsx
+++ b/src/app/agendabela/lista-de-espera/layout.tsx
@@ -1,0 +1,47 @@
+import { Metadata } from "next";
+
+const pageUrl = "https://tudoagenda.com.br/agendabela/lista-de-espera";
+const title = "Agenda Bela | Entre na lista de espera";
+const description =
+  "O Agenda Bela, a secretária digital para salões de beleza, está chegando. Deixe seu nome e WhatsApp e seja uma das primeiras a usar no lançamento.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: "/agendabela/lista-de-espera",
+  },
+  robots: {
+    index: false, // LP de campanha (pré-lançamento) — não indexar
+  },
+  openGraph: {
+    type: "website",
+    locale: "pt_BR",
+    url: pageUrl,
+    siteName: "Agenda Bela",
+    title,
+    description,
+    images: [
+      {
+        url: "/brand/agenda-bela/social-preview.png",
+        width: 1200,
+        height: 630,
+        alt: "Agenda Bela — Entre na lista de espera",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    images: ["/brand/agenda-bela/social-preview.png"],
+  },
+};
+
+export default function Layout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/src/app/agendabela/lista-de-espera/page.tsx
+++ b/src/app/agendabela/lista-de-espera/page.tsx
@@ -1,0 +1,90 @@
+import Image from "next/image";
+import { WaitlistForm } from "./waitlist-form";
+
+const benefits = [
+  "Confirma e lembra seus clientes no WhatsApp, no automático",
+  "Sua agenda do dia direto no celular toda manhã",
+  "Profissionais, serviços e horários organizados num lugar só",
+];
+
+const ListaDeEspera = () => {
+  return (
+    <main className="min-h-screen w-full bg-surface-subtle px-5 md:px-10 lg:px-20 py-8 md:py-12">
+      {/* Top bar — logo do app */}
+      <header className="flex items-center justify-between max-w-5xl mx-auto mb-8 md:mb-12">
+        <Image
+          src="/brand/logo-app.png"
+          alt="Agenda Bela"
+          width={72}
+          height={72}
+          priority
+          className="h-14 w-14 md:h-16 md:w-16"
+        />
+        <span className="hidden md:inline font-mono-brand text-[10px] tracking-[2px] uppercase text-brand-vinho">
+          por Tudo Agenda
+        </span>
+      </header>
+
+      <section className="relative max-w-5xl mx-auto overflow-hidden rounded-app-xl bg-brand-creme shadow-brand-md">
+        {/* Círculos decorativos */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -right-24 -bottom-24 h-72 w-72 md:h-80 md:w-80 rounded-full bg-brand-rosa-claro opacity-40"
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -left-32 -top-32 h-56 w-56 md:h-64 md:w-64 rounded-full bg-brand-creme-soft opacity-60"
+        />
+
+        <div className="relative grid grid-cols-1 lg:grid-cols-[1.1fr_1fr] gap-8 lg:gap-14 p-6 md:p-12 lg:p-16 items-center">
+          {/* Coluna esquerda — copy */}
+          <div className="flex flex-col gap-5 md:gap-6">
+            <span className="inline-flex w-fit items-center gap-2 rounded-full bg-brand-rosa-50 px-3 py-1 font-mono-brand text-[10px] tracking-[1.8px] uppercase text-brand-rosa">
+              Em breve
+            </span>
+
+            <h1 className="font-fraunces italic font-normal text-brand-petroleo text-[34px] leading-[38px] md:text-[52px] md:leading-[54px] tracking-[-0.035em] max-w-[16ch]">
+              O Agenda Bela está chegando.
+            </h1>
+
+            <p className="font-inter text-ink-muted text-[16px] leading-[24px] md:text-[18px] md:leading-[28px] max-w-[42ch]">
+              A secretária digital do seu salão. Deixa seu nome e WhatsApp pra
+              ser uma das{" "}
+              <span className="text-brand-petroleo font-medium">
+                primeiras a usar
+              </span>{" "}
+              quando lançar.
+            </p>
+
+            <ul className="flex flex-col gap-2.5">
+              {benefits.map((benefit) => (
+                <li
+                  key={benefit}
+                  className="flex items-start gap-2.5 font-inter text-[14.5px] text-ink"
+                >
+                  <span className="inline-flex h-5 w-5 mt-0.5 items-center justify-center rounded-full bg-brand-rosa-50 text-brand-rosa font-bold text-[12px]">
+                    ✓
+                  </span>
+                  <span>{benefit}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Coluna direita — form */}
+          <div className="w-full max-w-md mx-auto lg:mx-0">
+            <WaitlistForm />
+          </div>
+        </div>
+      </section>
+
+      <footer className="max-w-5xl mx-auto mt-8 text-center">
+        <span className="font-mono-brand text-[10px] tracking-[2px] uppercase text-ink-subtle">
+          Agenda Bela · por Tudo Agenda
+        </span>
+      </footer>
+    </main>
+  );
+};
+
+export default ListaDeEspera;

--- a/src/app/agendabela/lista-de-espera/waitlist-form.tsx
+++ b/src/app/agendabela/lista-de-espera/waitlist-form.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useAmplitude } from "@/contexts/AmplitudeProvider";
+import { pushAgendaBelaListaEsperaEvent } from "@/lib/analytics/dataLayer";
+
+// Máscara visual de telefone BR: (11) 91234-5678 / (11) 1234-5678.
+function maskPhone(value: string): string {
+  const digits = value.replace(/\D/g, "").slice(0, 11);
+  if (digits.length <= 2) return digits;
+  if (digits.length <= 6) return `(${digits.slice(0, 2)}) ${digits.slice(2)}`;
+  if (digits.length <= 10) {
+    return `(${digits.slice(0, 2)}) ${digits.slice(2, 6)}-${digits.slice(6)}`;
+  }
+  return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
+}
+
+type Status = "idle" | "loading" | "success" | "error";
+
+export const WaitlistForm = () => {
+  const [name, setName] = useState("");
+  const [whatsapp, setWhatsapp] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const { track } = useAmplitude();
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (status === "loading") return;
+
+    setStatus("loading");
+    setErrorMsg("");
+
+    track("agendabela/lista-de-espera/form_submission", {
+      whatsapp_digits: whatsapp.replace(/\D/g, "").length,
+    });
+    pushAgendaBelaListaEsperaEvent({
+      event: "lp_form_submitted",
+      form_name: "waitlist",
+    });
+
+    try {
+      const res = await fetch("/api/agendabela/waitlist", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, whatsapp }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        setErrorMsg(data?.error ?? "Não conseguimos salvar. Tente novamente.");
+        setStatus("error");
+        return;
+      }
+
+      pushAgendaBelaListaEsperaEvent({ event: "lp_signup_completed" });
+      setStatus("success");
+    } catch {
+      setErrorMsg("Sem conexão. Confira sua internet e tente de novo.");
+      setStatus("error");
+    }
+  };
+
+  if (status === "success") {
+    return (
+      <div className="flex flex-col gap-3 bg-white rounded-app-lg shadow-brand-md p-6 text-center">
+        <span className="mx-auto inline-flex h-12 w-12 items-center justify-center rounded-full bg-brand-rosa-50 text-brand-rosa text-2xl font-bold">
+          ✓
+        </span>
+        <h2 className="font-fraunces italic text-brand-petroleo text-[24px] leading-tight">
+          Tá feito, {name.split(" ")[0]}!
+        </h2>
+        <p className="font-inter text-ink-muted text-[15px] leading-[22px]">
+          Você está na lista. Assim que o Agenda Bela sair, a gente te chama no
+          WhatsApp — você vai ser uma das primeiras a usar.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-3 bg-white rounded-app-lg shadow-brand-md p-5 md:p-6"
+    >
+      <span className="font-mono-brand text-[10px] tracking-[1.8px] uppercase text-ink-muted">
+        Entre na lista de espera
+      </span>
+
+      <Input
+        placeholder="Seu nome"
+        type="text"
+        name="name"
+        autoComplete="name"
+        required
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="h-11 font-inter rounded-full"
+      />
+
+      <Input
+        placeholder="Seu WhatsApp com DDD"
+        type="tel"
+        name="whatsapp"
+        inputMode="numeric"
+        autoComplete="tel"
+        required
+        value={whatsapp}
+        onChange={(e) => setWhatsapp(maskPhone(e.target.value))}
+        className="h-11 font-inter rounded-full"
+      />
+
+      {status === "error" && (
+        <p className="font-inter text-[13px] leading-[18px] text-red-600" role="alert">
+          {errorMsg}
+        </p>
+      )}
+
+      <Button
+        variant="brand-primary"
+        size="lg"
+        type="submit"
+        disabled={status === "loading"}
+        className="rounded-full whitespace-nowrap"
+      >
+        {status === "loading" ? "Salvando..." : "Quero ser avisada no lançamento"}
+      </Button>
+
+      <p className="font-inter text-[12px] leading-[17px] text-ink-muted text-center">
+        Sem spam. A gente só te chama quando o app estiver no ar.
+      </p>
+    </form>
+  );
+};

--- a/src/app/api/agendabela/waitlist/route.ts
+++ b/src/app/api/agendabela/waitlist/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+
+/**
+ * BFF da lista de espera (pré-lançamento) do Agenda Bela.
+ *
+ * Recebe { name, whatsapp } do form da LP `/agendabela/lista-de-espera`,
+ * valida/normaliza e repassa pra um Google Apps Script Web App que faz
+ * append numa planilha do Google Sheets.
+ *
+ * Env vars (configurar no Railway):
+ * - AGENDABELA_WAITLIST_WEBHOOK_URL: URL `/exec` do Apps Script publicado.
+ * - AGENDABELA_WAITLIST_SECRET (opcional): segredo compartilhado, enviado no
+ *   corpo e validado pelo Apps Script pra evitar gravações de terceiros.
+ *
+ * Setup do Apps Script: ver docs/lista-de-espera-apps-script.md.
+ */
+
+// Normaliza telefone brasileiro pra dígitos. Aceita com/sem DDI 55.
+function normalizeWhatsapp(raw: string): string | null {
+  const digits = raw.replace(/\D/g, "");
+  // 10 dígitos (fixo c/ DDD) a 11 (celular c/ DDD); ou com DDI 55 -> 12/13.
+  if (digits.length === 10 || digits.length === 11) {
+    return `55${digits}`;
+  }
+  if ((digits.length === 12 || digits.length === 13) && digits.startsWith("55")) {
+    return digits;
+  }
+  return null;
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => null);
+
+    const name: string =
+      typeof body?.name === "string" ? body.name.trim() : "";
+    const whatsappRaw: string =
+      typeof body?.whatsapp === "string" ? body.whatsapp.trim() : "";
+
+    if (name.length < 2) {
+      return NextResponse.json(
+        { error: "Informe seu nome." },
+        { status: 400 },
+      );
+    }
+
+    const whatsapp = normalizeWhatsapp(whatsappRaw);
+    if (!whatsapp) {
+      return NextResponse.json(
+        { error: "Informe um WhatsApp válido com DDD." },
+        { status: 400 },
+      );
+    }
+
+    const webhookUrl = process.env.AGENDABELA_WAITLIST_WEBHOOK_URL;
+    if (!webhookUrl) {
+      console.error("[Waitlist] AGENDABELA_WAITLIST_WEBHOOK_URL não configurada.");
+      return NextResponse.json(
+        { error: "Cadastro temporariamente indisponível. Tente mais tarde." },
+        { status: 502 },
+      );
+    }
+
+    const sheetRes = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name,
+        whatsapp,
+        source: "lp/lista-de-espera",
+        secret: process.env.AGENDABELA_WAITLIST_SECRET ?? "",
+      }),
+      // Apps Script /exec responde com 302 -> seguir o redirect.
+      redirect: "follow",
+    });
+
+    // Apps Script (ContentService) responde 200 mesmo em erro de aplicação
+    // (ex.: segredo inválido), então checamos o corpo, não só o status HTTP.
+    const detail = await sheetRes.text().catch(() => "");
+    let payload: { ok?: boolean; error?: string } = {};
+    try {
+      payload = JSON.parse(detail);
+    } catch {
+      // corpo não-JSON
+    }
+
+    if (!sheetRes.ok || payload.ok !== true) {
+      console.error("[Waitlist] Apps Script error:", sheetRes.status, detail);
+      return NextResponse.json(
+        { error: "Não conseguimos salvar seu cadastro. Tente novamente." },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[Waitlist] Unexpected error:", err);
+    return NextResponse.json(
+      { error: "Erro interno. Tente novamente." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/analytics/dataLayer.ts
+++ b/src/lib/analytics/dataLayer.ts
@@ -76,6 +76,18 @@ export function pushAgendaBelaReativacaoEvent(eventData: LandingEvent): void {
 }
 
 /**
+ * Faz push de um evento da LP de lista de espera (pré-lançamento) do Agenda Bela.
+ * Contexto: campaign, slug = lista-de-espera.
+ */
+export function pushAgendaBelaListaEsperaEvent(eventData: LandingEvent): void {
+  pushLandingEvent(eventData, {
+    product: "agendabela",
+    landing_type: "campaign",
+    landing_slug: "lista-de-espera",
+  });
+}
+
+/**
  * Push genérico — só usar em componentes que sabem o contexto deles.
  * Componentes da landing principal devem usar pushAgendaBelaMainEvent.
  */


### PR DESCRIPTION
## O quê

LP pública **`/agendabela/lista-de-espera`** pra campanha de pré-lançamento no Instagram. Captura **nome + WhatsApp** e salva numa **planilha do Google** via Apps Script Web App. Sem backend novo, sem credenciais do Google no app.

## Por quê

Antes do lançamento do app, queremos divulgar no Instagram e deixar quem tiver interesse se cadastrar pra ser avisado. Caminho mais simples possível: planilha do Google da conta `tudoagendaagendabela@gmail.com`.

## Fluxo

```
Form (LP) → POST /api/agendabela/waitlist (BFF) → Apps Script /exec → append na planilha
```

## Mudanças

- **page/layout** (`lista-de-espera/`): hero "Em breve" no design system brand (Fraunces/Inter, brand-creme/rosa), OG configurado, `robots: noindex` (LP de campanha).
- **waitlist-form**: client component com máscara de telefone BR, estados `loading/success/error` inline, eventos GTM (`lp_form_submitted` + `lp_signup_completed`).
- **BFF** `/api/agendabela/waitlist`: valida nome, normaliza WhatsApp (digits, DDI 55), repassa pro Apps Script. Como o `ContentService` sempre responde 200, o BFF **valida o corpo** (`ok === true`).
- **dataLayer**: wrapper `pushAgendaBelaListaEsperaEvent` (slug `lista-de-espera`), seguindo o padrão dos outros LPs.
- **docs** `docs/lista-de-espera-apps-script.md`: código do Apps Script pronto + passo a passo de deploy e env vars.

## ⚠️ Setup necessário antes de funcionar (manual)

1. Colar o Apps Script da doc na planilha e publicar como Web App ("qualquer pessoa").
2. Configurar no Railway: `AGENDABELA_WAITLIST_WEBHOOK_URL` (URL `/exec`) e `AGENDABELA_WAITLIST_SECRET` (mesmo segredo do script).

Sem essas env vars o endpoint responde 502 com mensagem amigável.

## Validação

- `npx tsc --noEmit`: sem erros nos arquivos novos (erros restantes são pré-existentes de typings de teste).
- `npx next lint` nos arquivos: limpo.
- `npx next build`: compila; rota `/agendabela/lista-de-espera` estática, `/api/agendabela/waitlist` dinâmica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)