### PR TITLE
feat(analytics): complete landing event attribution

### DIFF
--- a/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
+++ b/src/app/agendabela/automatize-seu-atendimento/components/signup-modal/signup-modal.tsx
@@ -209,6 +209,11 @@ export const SignupModal = ({ open, onOpenChange, initialEmail, initialStep = 1 
       {
         onSuccess: (data) => {
           if (data.url) {
+            pushAgendaBelaMainEvent({
+              event: "checkout_opened",
+              flow: "new_signup",
+              source: "lp_signup_modal",
+            });
             window.location.href = data.url;
           }
         },

--- a/src/lib/analytics/dataLayer.ts
+++ b/src/lib/analytics/dataLayer.ts
@@ -50,6 +50,21 @@ type LandingContext = {
   landing_slug: string;
 };
 
+const ATTRIBUTION_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "gclid",
+  "fbclid",
+] as const;
+
+type AttributionKey = (typeof ATTRIBUTION_KEYS)[number];
+type AttributionContext = Partial<Record<AttributionKey, string>>;
+
+const ATTRIBUTION_STORAGE_KEY = "agendabela_landing_attribution";
+
 /**
  * Faz push de um evento da landing principal do Agenda Bela.
  * Componentes da landing principal usam `pushAgendaBelaMainEvent`.
@@ -97,5 +112,57 @@ export function pushLandingEvent(
 ): void {
   if (typeof window === "undefined") return;
   window.dataLayer = window.dataLayer || [];
-  window.dataLayer.push({ ...context, ...eventData });
+  window.dataLayer.push({
+    ...context,
+    ...getAttributionContext(),
+    ...eventData,
+  });
+}
+
+function getAttributionContext(): AttributionContext {
+  const currentAttribution = readAttributionFromUrl();
+
+  if (Object.keys(currentAttribution).length > 0) {
+    persistAttribution(currentAttribution);
+    return currentAttribution;
+  }
+
+  return readPersistedAttribution();
+}
+
+function readAttributionFromUrl(): AttributionContext {
+  const params = new URLSearchParams(window.location.search);
+
+  return ATTRIBUTION_KEYS.reduce<AttributionContext>((acc, key) => {
+    const value = params.get(key);
+    if (value) acc[key] = value;
+    return acc;
+  }, {});
+}
+
+function persistAttribution(attribution: AttributionContext): void {
+  try {
+    window.sessionStorage.setItem(
+      ATTRIBUTION_STORAGE_KEY,
+      JSON.stringify(attribution),
+    );
+  } catch {
+    // Storage can be unavailable in restricted browsers; analytics should keep working.
+  }
+}
+
+function readPersistedAttribution(): AttributionContext {
+  try {
+    const raw = window.sessionStorage.getItem(ATTRIBUTION_STORAGE_KEY);
+    if (!raw) return {};
+
+    const parsed = JSON.parse(raw) as AttributionContext;
+    return ATTRIBUTION_KEYS.reduce<AttributionContext>((acc, key) => {
+      const value = parsed[key];
+      if (typeof value === "string" && value) acc[key] = value;
+      return acc;
+    }, {});
+  } catch {
+    return {};
+  }
 }


### PR DESCRIPTION
## Summary
- persist landing attribution params (utm_source, utm_medium, utm_campaign, utm_content, utm_term, gclid, fbclid) into dataLayer events
- emit checkout_opened when the main signup flow receives a checkout URL
- aligns landing code with the published GTM v4 coverage for lp_*, paywall_viewed, and checkout_opened

## Validation
- npm run build
- local browser validation for lista-de-espera dataLayer events
- local browser validation for reativacao paywall_viewed and checkout_opened
- GTM v4 published successfully without compilerError

## Note
This branch was created from feat/lp-lista-de-espera, so the PR also includes that branch's waitlist landing commits if they are not already in main.